### PR TITLE
Beautify the code for Coq 8.7.2

### DIFF
--- a/CardFin.v
+++ b/CardFin.v
@@ -28,13 +28,13 @@ Lemma count_irrel : forall tst1 tst2 x l, count tst1 x l = count tst2 x l.
 Proof.
   intros tst1 tst2 x l.
   induction l as [ | a tl Ht].
-  reflexivity.
-  simpl; case (tst1 x a);[intros xa | intros xna];
+  { reflexivity. }
+  cbn; case (tst1 x a);[intros xa | intros xna];
     (case (tst2 x a);[intros xa' | intros xna']).
-  rewrite Ht ; reflexivity.
-  case xna'; assumption.
-  case xna; assumption.
-  apply Ht.
+  - rewrite Ht ; reflexivity.
+  - case xna'; assumption.
+  - case xna; assumption.
+  - apply Ht.
 Qed.
 
 (* An enumeration is a list that contains exactly once all the 
@@ -45,12 +45,12 @@ Lemma count_app (l1 l2 : list T)(t: T) :
   count T_eq_dec t (l1++l2) = count T_eq_dec t l1 + count T_eq_dec t l2.
 Proof.
   induction l1 as [|t1 l1 IH].
-  reflexivity.
-  simpl.
+  { reflexivity. }
+  cbn.
   elim (T_eq_dec t t1) ; intros a.
-  rewrite IH.
-  reflexivity.
-  apply IH.
+  - rewrite IH.
+    reflexivity.
+  - apply IH.
 Qed.
 
 Fixpoint rem1 x l :=
@@ -63,98 +63,98 @@ Lemma count_rem1_eq :
   forall x l, count T_eq_dec x l <> 0 ->
   count T_eq_dec x l = 1 + count T_eq_dec x (rem1 x l).
 Proof.
-intros x; induction l as [ | a tl Ht].
-  intros abs; case abs; reflexivity.
-simpl; case_eq (T_eq_dec x a); simpl.
-  intros _ _ _; reflexivity.
-intros n tst cn0; rewrite tst.
-  apply Ht; assumption.
+  intros x; induction l as [ | a tl Ht].
+  - intros abs; case abs; reflexivity.
+  - cbn; case_eq (T_eq_dec x a); cbn.
+    + intros _ _ _; reflexivity.
+    + intros n tst cn0; rewrite tst.
+      apply Ht; assumption.
 Qed.
 
 Lemma count_rem1_eq_length :
   forall x l, count T_eq_dec x l <> 0 -> length l = S (length (rem1 x l)). 
 Proof.
-  intros x ; induction l as [|t l IH]. 
-  intros H1.
-  apply False_rec, H1, eq_refl.
-  simpl.
-  elim (T_eq_dec x t) ; intros H1 H2 ; f_equal.
-  apply (IH H2).
+  intros x ; induction l as [|t l IH].
+  - intros H1.
+    apply False_rec, H1, eq_refl.
+  - cbn.
+    elim (T_eq_dec x t) ; intros H1 H2 ; f_equal.
+    apply (IH H2).
 Qed.
 
 Lemma count_rem1_diff :
   forall x y l, x <> y -> count T_eq_dec y l = count T_eq_dec y (rem1 x l).
 Proof.
-intros x y l xny; induction l as [ | a tl Ht].
-  reflexivity.
-simpl; case_eq (T_eq_dec y a); intros ya tya.
-  case (T_eq_dec x a).
-    intros xa; case xny; rewrite ya; assumption.
-  simpl; rewrite tya, Ht; reflexivity.
-case (T_eq_dec x a); [reflexivity | simpl; rewrite Ht, tya; reflexivity].
+  intros x y l xny; induction l as [ | a tl Ht].
+  { reflexivity. }
+  cbn; case_eq (T_eq_dec y a); intros ya tya.
+  - case (T_eq_dec x a).
+    + intros xa; case xny; rewrite ya; assumption.
+    + cbn; rewrite tya, Ht; reflexivity.
+  - case (T_eq_dec x a); [reflexivity | cbn; rewrite Ht, tya; reflexivity].
 Qed.
 
 Lemma count_rem1_diff_length :
   forall x l, count T_eq_dec x l = 0 -> length l = length (rem1 x l).
 Proof.
   intros x l H; induction l as [ | t l IH].
-  reflexivity.
-  revert H ; simpl; elim (T_eq_dec x t) ; intros H1 H.
-  inversion H.
-  simpl ; f_equal.
-  apply IH, H.
+  { reflexivity. }
+  revert H ; cbn; elim (T_eq_dec x t) ; intros H1 H.
+  - inversion H.
+  - cbn ; f_equal.
+    apply IH, H.
 Qed.
 
 Lemma rem1_cons_eq :
   forall x l, rem1 x (x::l) = l.
 Proof.
   intros x l.
-  simpl.
+  cbn.
   elim (T_eq_dec x x) ; intros H.
-  reflexivity.
-  apply False_rec, H, eq_refl.
+  - reflexivity.
+  - apply False_rec, H, eq_refl.
 Qed.
 
 Lemma rem1_cons_diff :
   forall x y l, x <> y -> rem1 x (y :: l) = y :: rem1 x l.
 Proof.
   intros x y l H1.
-  simpl.
+  cbn.
   elim (T_eq_dec x y) ; intros H2.
-  contradiction H1.
-  reflexivity.
+  - contradiction H1.
+  - reflexivity.
 Qed.
 
 Lemma count_cons_eq :
   forall x l, count T_eq_dec x (x :: l) = S (count T_eq_dec x l).
 Proof.
   intros x l.
-  simpl.
+  cbn.
   elim (T_eq_dec x x) ; intros H1.
-  reflexivity.
-  apply False_rec, H1, eq_refl.
+  - reflexivity.
+  - apply False_rec, H1, eq_refl.
 Qed.
 
 Lemma count_cons_diff :
   forall x y l, x <> y -> count T_eq_dec x (y :: l) = count T_eq_dec x l.
 Proof.
   intros x y l H1.
-  simpl.
+  cbn.
   elim (T_eq_dec x y) ; intros H2.
-  contradiction H1.
-  reflexivity.
+  - contradiction H1.
+  - reflexivity.
 Qed.
 
 Lemma rem1_count_inf : forall x y l, count T_eq_dec x (rem1 y l) <= count T_eq_dec x l.
 Proof.
   intros x y ; induction l as [|t l IH].
   apply le_refl.
-  simpl.
-  elim (T_eq_dec y t) ; simpl ; elim (T_eq_dec x t) ; intros H1 H2.
-  apply le_n_Sn.
-  apply le_refl.
-  apply le_n_S, IH.
-  apply IH.
+  cbn.
+  elim (T_eq_dec y t) ; cbn ; elim (T_eq_dec x t) ; intros H1 H2.
+  - apply le_n_Sn.
+  - apply le_refl.
+  - apply le_n_S, IH.
+  - apply IH.
 Qed.
 
 Lemma rem1_count_0 :
@@ -197,65 +197,63 @@ Lemma indep_enum:
 Proof.
   assert (aux : forall l1 l2 l3, 
     is_enum (l3++l1) -> is_enum (l3++l2) -> length l1 = length l2).
-  induction l1 as [|t1 l1 IH1] ; intros [|t2 l2] l3 H1 H2.
-  reflexivity.
-  rewrite app_nil_r in H1.
-  assert (H3 := is_enum_eq_cor1 _ _ _ H2).
-  rewrite (H1 t2) in H3.
-  inversion H3.
-
-  rewrite app_nil_r in H2.
-  assert (H3 := is_enum_eq_cor1 _ _ _ H1).
-  rewrite (H2 t1) in H3.
-  inversion H3.
-
-  assert (H3 : length (t2 :: l2) = length (t1::rem1 t1 (t2::l2))).
-  simpl.
-  elim (T_eq_dec t1 t2) ; intros a.
-  reflexivity.
-  simpl.
-  f_equal.
-  rewrite <- count_rem1_eq_length.
-  reflexivity.
-  intros H.
-  assert (H2' := H2 t1).
-  rewrite count_app, count_cons_diff, H, (is_enum_eq_cor1 _ _ _ H1) in H2' ; try apply a.
-  inversion H2'.
-  rewrite H3.
-  change (S (length l1) = S (length (rem1 t1 (t2 :: l2)))).
-  f_equal.
-  elim (T_eq_dec t1 t2) ; intros a.
-  rewrite a.
-  rewrite rem1_cons_eq.
-  rewrite <- a in H2.
-  apply (IH1 _ (l3 ++ t1 :: nil)) ;
-  rewrite <- app_assoc, <- app_comm_cons, app_nil_l ; assumption.
-
-  rewrite rem1_cons_diff; try apply a.
-  apply (IH1 (t2 :: rem1 t1 l2) (l3 ++ t1 :: nil)).
-  rewrite <- app_assoc, <- app_comm_cons, app_nil_l ; assumption.
-  rewrite <- app_assoc, <- app_comm_cons, app_nil_l.
-  intros x.
-  generalize (H2 x).
-  do 2 rewrite count_app.
-  simpl.
-  elim (T_eq_dec x t2) ; elim (T_eq_dec x t1) ; intros H4 H5 H6 ; 
-  try (rewrite <- H4 in *|-* ; clear H4) ; try (rewrite <- H5 in *|-* ; clear H5).
-  apply False_rec, a, eq_refl.
-  rewrite <- H6 ; do 2 f_equal.
-  rewrite (is_enum_eq_cor2 _ _ _ H2).
-  apply rem1_count_0, (is_enum_eq_cor2 _ _ _ H2).
-  rewrite <- H6 ; f_equal.
-  rewrite (count_rem1_eq x l2).
-  reflexivity.
-  intros H7.
-  rewrite (is_enum_eq_cor1 _ _ _ H1), H7 in H6.
-  inversion H6.
-
-  rewrite <- H6 ; f_equal.
-  rewrite <- count_rem1_diff.
-  reflexivity.
-  apply not_eq_sym, H4.
+  { induction l1 as [|t1 l1 IH1] ; intros [|t2 l2] l3 H1 H2.
+    + reflexivity.
+    + rewrite app_nil_r in H1.
+      assert (H3 := is_enum_eq_cor1 _ _ _ H2).
+      rewrite (H1 t2) in H3.
+      inversion H3.
+    + rewrite app_nil_r in H2.
+      assert (H3 := is_enum_eq_cor1 _ _ _ H1).
+      rewrite (H2 t1) in H3.
+      inversion H3.
+    + assert (H3 : length (t2 :: l2) = length (t1::rem1 t1 (t2::l2))).
+      { cbn.
+        elim (T_eq_dec t1 t2) ; intros a.
+        * reflexivity.
+        * cbn.
+          f_equal.
+          rewrite <- count_rem1_eq_length.
+          -- reflexivity.
+          -- intros H.
+             assert (H2' := H2 t1).
+             rewrite count_app, count_cons_diff, H, (is_enum_eq_cor1 _ _ _ H1) in H2' ; try apply a.
+             inversion H2'.
+      }
+      rewrite H3.
+      change (S (length l1) = S (length (rem1 t1 (t2 :: l2)))).
+      f_equal.
+      elim (T_eq_dec t1 t2) ; intros a.
+      * rewrite a.
+        rewrite rem1_cons_eq.
+        rewrite <- a in H2.
+        apply (IH1 _ (l3 ++ t1 :: nil)) ;
+          rewrite <- app_assoc, <- app_comm_cons, app_nil_l ; assumption.
+      * rewrite rem1_cons_diff; try apply a.
+        apply (IH1 (t2 :: rem1 t1 l2) (l3 ++ t1 :: nil)).
+        -- rewrite <- app_assoc, <- app_comm_cons, app_nil_l ; assumption.
+        -- rewrite <- app_assoc, <- app_comm_cons, app_nil_l.
+           intros x.
+           generalize (H2 x).
+           do 2 rewrite count_app.
+           cbn.
+           elim (T_eq_dec x t2) ; elim (T_eq_dec x t1) ; intros H4 H5 H6 ; 
+             try (rewrite <- H4 in *|-* ; clear H4) ; try (rewrite <- H5 in *|-* ; clear H5).
+           ++ apply False_rec, a, eq_refl.
+           ++ rewrite <- H6 ; do 2 f_equal.
+              rewrite (is_enum_eq_cor2 _ _ _ H2).
+              apply rem1_count_0, (is_enum_eq_cor2 _ _ _ H2).
+           ++ rewrite <- H6 ; f_equal.
+              rewrite (count_rem1_eq x l2).
+              ** reflexivity.
+              ** intros H7.
+                 rewrite (is_enum_eq_cor1 _ _ _ H1), H7 in H6.
+                 inversion H6.
+           ++ rewrite <- H6 ; f_equal.
+              rewrite <- count_rem1_diff.
+              ** reflexivity.
+              ** apply not_eq_sym, H4.
+  }
   intros l1 l2 H1 H2.
   apply (aux _ _ nil) ; rewrite app_nil_l ; assumption.
 Qed.
@@ -268,22 +266,22 @@ Lemma eq_dec_Fin (n: nat) : eq_dec (Fin n).
 Proof.
   intros i1 i2.
   elim (eq_nat_dec (decode_Fin i1) (decode_Fin i2)) ; intros a.
-  left.
-  apply decode_Fin_unique, a.
-  right.
-  intros b.
-  apply a ; rewrite b ; reflexivity.
+  - left.
+    apply decode_Fin_unique, a.
+  - right.
+    intros b.
+    apply a ; rewrite b ; reflexivity.
 Qed.
 
 Lemma first_succ_count_0 (n: nat)(l: list (Fin n)): 
   count (@eq_dec_Fin _) (first n) (map (@succ _) l) = 0.
 Proof.
   induction l as [|t l IH].
-  trivial.
-  simpl.
+  { trivial. }
+  cbn.
   elim (eq_dec_Fin (first n) (succ t)) ; intros a.
-  inversion a.
-  apply IH.
+  - inversion a.
+  - apply IH.
 Qed.
 
 Definition injective (T U : Set)(f: T -> U) : Prop :=
@@ -294,19 +292,18 @@ Lemma count_map (T U : Set)(tstT : eq_dec T)
   forall t, count tstT t l = count tstU (f t) (map f l).
 Proof.
   induction l as [|tt l IH] ; intros t.
-  reflexivity.
-  simpl.
+  { reflexivity. }
+  cbn.
   rewrite IH.
   elim (tstT t tt) ; intros a.
-  rewrite a.
-  elim (tstU (f tt) (f tt)) ; intros b.
-  reflexivity.
-  apply False_rec, b ; reflexivity.
-  
-  elim (tstU (f t) (f tt)) ; intros b.
-  apply h in b.
-  contradiction a.
-  reflexivity.
+  - rewrite a.
+    elim (tstU (f tt) (f tt)) ; intros b.
+    + reflexivity.
+    + apply False_rec, b ; reflexivity.
+  - elim (tstU (f t) (f tt)) ; intros b.
+    + apply h in b.
+      contradiction a.
+    + reflexivity.
 Qed.
 
 Lemma succ_inj (n: nat) : injective (@succ n).
@@ -322,17 +319,17 @@ Qed.
 Lemma enum_makeListFin : forall n, is_enum (@eq_dec_Fin _) (makeListFin n).
 Proof.
   induction n as [|n IH] ; intros i.
-  inversion i.
-  simpl.
+  { inversion i. }
+  cbn.
   elim (eq_dec_Fin i (first n)) ; intros a.
-  rewrite a.
-  rewrite first_succ_count_0.
-  reflexivity.
-  elim (zerop (decode_Fin i)) ; intros b.
-  contradiction a.
-  apply (decode_Fin_0_first _ b).
-  rewrite <- (get_cons_ok1 _ b), <- (count_map (@eq_dec_Fin _) _ (@succ_inj _)).
-  apply IH.
+  - rewrite a.
+    rewrite first_succ_count_0.
+    reflexivity.
+  - elim (zerop (decode_Fin i)) ; intros b.
+    + contradiction a.
+      apply (decode_Fin_0_first _ b).
+    + rewrite <- (get_cons_ok1 _ b), <- (count_map (@eq_dec_Fin _) _ (@succ_inj _)).
+      apply IH.
 Qed.
 
 

--- a/EquivContejean.v
+++ b/EquivContejean.v
@@ -29,58 +29,54 @@ Lemma equiv_list_permut_IlistPerm3 (T: Set)(R: relation T):
 Proof.
   intros l1 l2 H.
   induction H as [| a b l l1 l2 H1 H2 IH].
-  apply IlistPerm3nil.
-
+  { apply IlistPerm3nil. }
   assert (h: length l1 < lgti (list2ilist (l1 ++ b :: l2))).
-  cbn.
-  rewrite app_length.
-  apply lt_plus_S.
+  { cbn.
+    rewrite app_length.
+    apply lt_plus_S. }
   apply (IlistPerm3_cons _ _ (first _ : Fin (lgti (list2ilist (a :: l)))) (code_Fin1 h)).
-  do 2 rewrite <- (list2ilist_nth2 _ _ b).
-  fold (length l).
-  rewrite decode_code1_Id.
-  rewrite (app_nth2 _ _ b (le_refl _)).
-  rewrite minus_diag.
-  assumption.
-
-  assert (H3 : ilist_rel eq (list2ilist l) (extroduce (list2ilist (a :: l)) (first _))).
-  simpl.
-  set (Hyp1 := refl_equal _ : lgti (list2ilist l) = lgti (mkilist (fun x => nth (decode_Fin x) l a))).
-  apply (is_ilist_rel eq _ _ Hyp1).
-  cbn in *|-*.
-  intro i.
-  symmetry. 
-  apply (list2ilist_nth2 l).
-
-  assert (H4 : ilist_rel eq (list2ilist (l1 ++ l2))
+  - do 2 rewrite <- (list2ilist_nth2 _ _ b).
+    fold (length l).
+    rewrite decode_code1_Id.
+    rewrite (app_nth2 _ _ b (le_refl _)).
+    rewrite minus_diag.
+    assumption.
+  - assert (H3 : ilist_rel eq (list2ilist l) (extroduce (list2ilist (a :: l)) (first _))).
+    { cbn.
+      set (Hyp1 := refl_equal _ : lgti (list2ilist l) = lgti (mkilist (fun x => nth (decode_Fin x) l a))).
+      apply (is_ilist_rel eq _ _ Hyp1).
+      cbn in *|-*.
+      intro i.
+      symmetry. 
+      apply (list2ilist_nth2 l). }
+    assert (H4 : ilist_rel eq (list2ilist (l1 ++ l2))
     (extroduce (list2ilist (l1 ++ b :: l2)) (code_Fin1 h))).
-  assert (h1 : lgti (list2ilist (l1 ++ l2)) = 
+    + assert (h1 : lgti (list2ilist (l1 ++ l2)) = 
     lgti (extroduce (list2ilist (l1 ++ b :: l2)) (code_Fin1 h))).
-  apply eq_add_S.
-  rewrite <- extroduce_lgti.
-  apply list2ilist_app_lgti.
-  apply (is_ilist_rel _ _ _ h1).
-  intros i ; simpl in i.
-  rewrite <- (list2ilist_nth2 _ _ b).
-  elim (le_lt_dec (decode_Fin (code_Fin1 h)) (decode_Fin (rewriteFins h1 i))) ; intros h2.
-  rewrite extroduce_ok3' ; try assumption.
-  rewrite <- (list2ilist_nth2 _ _ b).
-  rewrite <- decode_Fin_match'.
-  simpl.
-  rewrite <- decode_Fin_match'.
-  rewrite <- decode_Fin_match', decode_code1_Id in h2.
-  rewrite app_nth2, app_nth2 ; try assumption.
-  rewrite <- minus_Sn_m ; try assumption.
-  reflexivity.
-  apply (le_trans _ _ _ h2 (le_n_Sn _)).
-
-  rewrite extroduce_ok2' ; try assumption.
-  rewrite <- (list2ilist_nth2 _ _ b).
-  rewrite <- decode_Fin_match', weakFin_ok, <- decode_Fin_match'.
-  rewrite <- decode_Fin_match', decode_code1_Id in h2.
-  rewrite app_nth1, app_nth1 ; try assumption.
-  reflexivity.
-  apply (IlistPerm3_ilist_rel_eq H3), (IlistPerm3_ilist_rel_eq_snd H4), IH.
+      { apply eq_add_S.
+        rewrite <- extroduce_lgti.
+        apply list2ilist_app_lgti. }
+      apply (is_ilist_rel _ _ _ h1).
+      intros i ; cbn in i.
+      rewrite <- (list2ilist_nth2 _ _ b).
+      elim (le_lt_dec (decode_Fin (code_Fin1 h)) (decode_Fin (rewriteFins h1 i))) ; intros h2.
+      * rewrite extroduce_ok3' ; try assumption.
+        rewrite <- (list2ilist_nth2 _ _ b).
+        rewrite <- decode_Fin_match'.
+        cbn.
+        rewrite <- decode_Fin_match'.
+        rewrite <- decode_Fin_match', decode_code1_Id in h2.
+        rewrite app_nth2, app_nth2 ; try assumption.
+        -- rewrite <- minus_Sn_m ; try assumption.
+           reflexivity.
+        -- apply (le_trans _ _ _ h2 (le_n_Sn _)).
+      * rewrite extroduce_ok2' ; try assumption.
+        rewrite <- (list2ilist_nth2 _ _ b).
+        rewrite <- decode_Fin_match', weakFin_ok, <- decode_Fin_match'.
+        rewrite <- decode_Fin_match', decode_code1_Id in h2.
+        rewrite app_nth1, app_nth1 ; try assumption.
+        reflexivity.
+    + apply (IlistPerm3_ilist_rel_eq H3), (IlistPerm3_ilist_rel_eq_snd H4), IH.
 Qed.
 
 Lemma equiv_ilist_IlistPerm3_permut (T: Set)(R: relation T): 
@@ -91,28 +87,24 @@ Proof.
   induction H1 as [l1 l2 H2 IH] using IlistPerm4_ind_better.
   destruct l1 as [n l1] ; destruct l2 as [n2 l2].
   fold (mkilist l1) (mkilist l2) in *|-*.
-  simpl in H2. 
+  cbn in H2. 
   revert l2 IH ; rewrite <- H2  ; clear n2 H2 ; intros l2 IH.
   destruct n as [|n].
-  apply Pnil.
-
-  simpl fcti in IH.
-  simpl (lgti (mkilist _)) in IH.
-  
-  destruct (IH (first n)) as [i2 [H1 [_ H3]]] ; clear IH.
-
-  assert (H4 := left_sib_right_sib (mkilist l2) i2).
-  assert (H5 : ilist2list (mkilist l1) = l1 (first n) :: ilist2list (mkilist (fun x => l1 (succ x)))).
-  unfold ilist2list.
-  simpl.
-  f_equal.
-  apply map_map.
-  rewrite <- H4, H5 ; clear H4 H5.
-  
-  apply Pcons.
-  assumption.
-  rewrite left_right_sib_extroduce_bis.
-  assumption.
+  - apply Pnil.
+  - simpl fcti in IH.
+    simpl (lgti (mkilist _)) in IH.
+    destruct (IH (first n)) as [i2 [H1 [_ H3]]] ; clear IH.
+    assert (H4 := left_sib_right_sib (mkilist l2) i2).
+    assert (H5 : ilist2list (mkilist l1) = l1 (first n) :: ilist2list (mkilist (fun x => l1 (succ x)))).
+    { unfold ilist2list.
+      cbn.
+      f_equal.
+      apply map_map. }
+    rewrite <- H4, H5 ; clear H4 H5.
+    apply Pcons.
+    + assumption.
+    + rewrite left_right_sib_extroduce_bis.
+      assumption.
 Qed.
 
 Lemma equiv_list_IlistPerm3_permut' (T: Set)(R: relation T): 

--- a/Extroduce.v
+++ b/Extroduce.v
@@ -18,24 +18,24 @@ Set Implicit Arguments.
    Proof.
      intros T [n i] f.
      induction n as [|n IH].
-     inversion f.
-     elim (zerop (decode_Fin f)) ; intros a.
-     exact (mkilist (fun x => i (succ x))).
-     exact (icons (i (first n)) (IH (fun x => (i (succ x))) (get_cons _ a))).
+     - inversion f.
+     - elim (zerop (decode_Fin f)) ; intros a.
+       + exact (mkilist (fun x => i (succ x))).
+       + exact (icons (i (first n)) (IH (fun x => (i (succ x))) (get_cons _ a))).
    Defined.
    
    Lemma extroduce_lgti: forall (T: Set)(i: ilist T)(f: Fin (lgti i)),
      lgti i = S (lgti (extroduce i f)).
    Proof.
      intros T [n i] f.
-     simpl in *|-*.
+     cbn in *|-*.
      unfold nat_rec, nat_rect, sumbool_rec, sumbool_rect, icons, mkilist.
      induction n as [|n IH].
-     inversion f.
-     apply eq_S.
-     elim (zerop (decode_Fin f)) ; intros a.
-     reflexivity.
-     apply IH.
+     - inversion f.
+     - apply eq_S.
+       elim (zerop (decode_Fin f)) ; intros a.
+       + reflexivity.
+       + apply IH.
    Defined.
 
    Hint Rewrite <- extroduce_lgti: evalLgti.
@@ -52,13 +52,13 @@ Set Implicit Arguments.
      RelT (ihead (extroduce i f) (fcti i f)) (ihead i (fcti i f)).
    Proof.
      intros T RelT [Rrefl _ _] [n i] f h.
-     simpl in *|-*.
+     cbn in *|-*.
      unfold nat_rec, nat_rect, sumbool_rec, sumbool_rect, iconsn.
      destruct n as [|n].
-     inversion f.
-     elim (zerop (decode_Fin f)) ; intros a.
-     apply False_rec ; rewrite <- a in h ; apply (lt_irrefl _ h).
-     apply Rrefl.
+     - inversion f.
+     - elim (zerop (decode_Fin f)) ; intros a.
+       + apply False_rec ; rewrite <- a in h ; apply (lt_irrefl _ h).
+       + apply Rrefl.
    Qed.
 
    Lemma extroduce_ok2: forall (T: Set)
@@ -69,8 +69,7 @@ Set Implicit Arguments.
    Proof.
      intros T [n i] f f' h.
      fold (mkilist i) in *|-*.
-     simpl in f.
-
+     cbn in f.
      assert (e:= lt_S _ _ (decode_Fin_inf_n f')).
      rewrite (code_Fin1_proofirr _ e).
      assert (e1 := sym_eq (extroduce_lgti (mkilist i) f)).
@@ -80,41 +79,38 @@ Set Implicit Arguments.
      rewrite e3 ; clear e3.
      change (fcti (mkilist i)) with (i).
      assert (e3 : decode_Fin f' < n).
-     rewrite <- e1.
-     assumption.
+     { rewrite <- e1.
+       assumption. }
      assert (e4: rewriteFins e1 (code_Fin1 e) = code_Fin1 e3) by treatFinPure.
      rewrite e4 ; clear e4 e1 e.
      induction n as [|n IH].
-     inversion f.
-
+     { inversion f. }
      revert f' h e3.
-     simpl.
+     cbn.
      unfold sumbool_rec, sumbool_rect.
-     elim (zerop (decode_Fin f)) ; simpl ; intros a f' e1 e2.
-     rewrite a in e1.
-     inversion e1.
-     
-     elim (zerop (decode_Fin f')) ; intros b.
-     revert e2 ; rewrite b ; intro e2.
-     rewrite code_Fin1_Sn_0, (decode_Fin_0_first _ b).
-     reflexivity.
-
-     assert (h1 : f' = succ (get_cons f' b)) by treatFinPure.
-     revert e1 e2 ; rewrite h1 ; intros e1 e2 ; clear h1.
-     simpl.
-     change ((fcti (extroduce (mkilist (fun x : Fin n => i (succ x))) (get_cons f a)) (get_cons f' b)) =
+     elim (zerop (decode_Fin f)) ; cbn ; intros a f' e1 e2.
+     - rewrite a in e1.
+       inversion e1.
+     - elim (zerop (decode_Fin f')) ; intros b.
+       + revert e2 ; rewrite b ; intro e2.
+         rewrite code_Fin1_Sn_0, (decode_Fin_0_first _ b).
+         reflexivity.
+       + assert (h1 : f' = succ (get_cons f' b)) by treatFinPure.
+         revert e1 e2 ; rewrite h1 ; intros e1 e2 ; clear h1.
+         cbn.
+         change ((fcti (extroduce (mkilist (fun x : Fin n => i (succ x))) (get_cons f a)) (get_cons f' b)) =
                   (i (code_Fin1_Sn (lt_n_Sm_le _ _ e2)))).
-     assert (e3: decode_Fin (get_cons f' b) < decode_Fin (get_cons f a)).
-     apply lt_S_n.
-     rewrite <- (decode_Fin_get_cons f a).
-     assumption.
-     assert (e4 : decode_Fin (get_cons f' b) < n).
-     apply (lt_S_n _ _ e2).
-     rewrite (IH _ _ _ e3 e4).
-     f_equal.
-     change (succ (code_Fin1 e4) = code_Fin1 e2).
-     apply decode_Fin_unique.
-     treatFinPure.
+         assert (e3: decode_Fin (get_cons f' b) < decode_Fin (get_cons f a)).
+         { apply lt_S_n.
+           rewrite <- (decode_Fin_get_cons f a).
+           assumption. }
+         assert (e4 : decode_Fin (get_cons f' b) < n).
+         { apply (lt_S_n _ _ e2). }
+         rewrite (IH _ _ _ e3 e4).
+         f_equal.
+         change (succ (code_Fin1 e4) = code_Fin1 e2).
+         apply decode_Fin_unique.
+         treatFinPure.
    Qed.
 
    Lemma extroduce_ok3 : forall (T: Set)(i: ilist T)(f: Fin (lgti i))(f': Fin (lgti (extroduce i f)))
@@ -127,45 +123,40 @@ Set Implicit Arguments.
      assert (e1:= decode_Fin_inf_n (succ f')).
      rewrite <- extroduce_lgti in e1.
      assert (e2: rewriteFins (sym_eq (extroduce_lgti i f))(succ f') = code_Fin1 e1).
-     treatFinPure.
+     { treatFinPure. }
      rewrite e2 ; clear e2.
      destruct i as [n i].
      fold (mkilist i) in *|-*.
      simpl fcti at 2.
      simpl in f, e1.
-     
      induction n as [|n IH].
-     inversion e1.
-     
+     { inversion e1. }
      revert f' h e1.
-     simpl.
+     cbn.
      unfold sumbool_rec, sumbool_rect.
-     elim (zerop (decode_Fin f)) ; simpl ; intros a f' h e1.
-     fold (code_Fin1 e1).
-     f_equal.
-     treatFinPure.
-     
-     elim (zerop (decode_Fin f')) ; intros b;
-     change (Fin (S (lgti (extroduce (mkilist (fun x : Fin n => i (succ x))) (get_cons f a))))) in f'.
-     rewrite b in h.
-     apply False_rec.
-     apply (lt_irrefl _ (lt_le_trans _ _ _ a h)).
-
-     assert (h1 : f' = succ (get_cons f' b)) by treatFinPure.
-     revert e1 ; rewrite h1 ; intros e1 ; clear h1.
-     
-     (* by looking closely: *)
-     change ((fcti (extroduce (mkilist (fun x : Fin n => i (succ x))) (get_cons f a)) (get_cons f' b)) =
-                  (i (code_Fin1_Sn (lt_n_Sm_le _ _ e1)))).
-     assert (e3: decode_Fin (get_cons f a) <= decode_Fin (get_cons f' b)).
-     treatFinAss.
-     assert (e4 : S (decode_Fin (get_cons f' b)) < n).
-     apply (lt_S_n _ _ e1).
-     change ((fcti (extroduce (mkilist (fun x : Fin n => i (succ x))) (get_cons f a)) (get_cons f' b)) =
-       (i (code_Fin1 e1))).
-     rewrite (IH (fun x : Fin n => i (succ x)) _ _ e3 e4).
-     f_equal.
-     treatFinPure.
+     elim (zerop (decode_Fin f)) ; cbn ; intros a f' h e1.
+     - fold (code_Fin1 e1).
+       f_equal.
+       treatFinPure.
+     - elim (zerop (decode_Fin f')) ; intros b;
+         change (Fin (S (lgti (extroduce (mkilist (fun x : Fin n => i (succ x))) (get_cons f a))))) in f'.
+       + rewrite b in h.
+         apply False_rec.
+         apply (lt_irrefl _ (lt_le_trans _ _ _ a h)).
+       + assert (h1 : f' = succ (get_cons f' b)) by treatFinPure.
+         revert e1 ; rewrite h1 ; intros e1 ; clear h1.
+         (* by looking closely: *)
+         change ((fcti (extroduce (mkilist (fun x : Fin n => i (succ x))) (get_cons f a)) (get_cons f' b)) =
+                 (i (code_Fin1_Sn (lt_n_Sm_le _ _ e1)))).
+         assert (e3: decode_Fin (get_cons f a) <= decode_Fin (get_cons f' b)).
+         { treatFinAss. }
+         assert (e4 : S (decode_Fin (get_cons f' b)) < n).
+         { apply (lt_S_n _ _ e1). }
+         change ((fcti (extroduce (mkilist (fun x : Fin n => i (succ x))) (get_cons f a)) (get_cons f' b)) =
+                 (i (code_Fin1 e1))).
+         rewrite (IH (fun x : Fin n => i (succ x)) _ _ e3 e4).
+         f_equal.
+         treatFinPure.
    Qed.
 
 (* we want to understand better aux_extroduce_ok2 by help of the following definition *)
@@ -179,10 +170,10 @@ Set Implicit Arguments.
    Proof.
      intros n f.
      induction f as [k|k f IH].
-     reflexivity.
-     simpl.
-     rewrite IH.
-     reflexivity.
+     - reflexivity.
+     - cbn.
+       rewrite IH.
+       reflexivity.
    Qed.
   
    Hint Rewrite weakFin_ok: evalDecode_FinDb.
@@ -234,10 +225,10 @@ Set Implicit Arguments.
      exists f1': Fin (lgti i1), fcti (extroduce i1 f1) f0 = fcti i1 f1'.
    Proof.
     elim (le_lt_dec (decode_Fin f1) (decode_Fin f0)) ; intros a.
-    exists (rewriteFins (eq_sym (extroduce_lgti i1 f1)) (succ f0)).
-    apply extroduce_ok3', a.
-    exists (rewriteFins (eq_sym (extroduce_lgti i1 f1)) (weakFin f0)).
-    apply extroduce_ok2', a.
+    - exists (rewriteFins (eq_sym (extroduce_lgti i1 f1)) (succ f0)).
+      apply extroduce_ok3', a.
+    - exists (rewriteFins (eq_sym (extroduce_lgti i1 f1)) (weakFin f0)).
+      apply extroduce_ok2', a.
    Qed.
  
    Lemma extroduce_ilist_rel (T: Set)(RelT: relation T)(n: nat)(l1 l2 : ilistn T n)
@@ -246,43 +237,41 @@ Set Implicit Arguments.
    Proof.
      intros [h1 H1].
      assert (h2 : lgti (extroduce (mkilist l1) i) = lgti (extroduce (mkilist l2) i)).
-     apply eq_add_S.
-     do 2 rewrite <- extroduce_lgti.
-     reflexivity.
+     { apply eq_add_S.
+       do 2 rewrite <- extroduce_lgti.
+       reflexivity. }
      assert (H1' : forall i, RelT (l1 i) (l2 i)).
-     intros i'.
-     rewrite (decode_Fin_unique _ _ (decode_Fin_match' i' h1)) at 2.
-     apply H1.
+     { intros i'.
+       rewrite (decode_Fin_unique _ _ (decode_Fin_match' i' h1)) at 2.
+       apply H1. }
      clear H1.
-     
      apply (is_ilist_rel _ _ _ h2).
      intro i'.
      elim (le_lt_dec (decode_Fin i) (decode_Fin i')) ; intros a.
-     rewrite extroduce_ok3' ; try assumption.
-     rewrite (decode_Fin_match' i' h2) in a.
-     rewrite extroduce_ok3' ; try assumption.
-     assert (H4 : rewriteFins (Logic.eq_sym (extroduce_lgti (mkilist l2) i)) (succ (rewriteFins h2 i')) = 
-       rewriteFins (eq_sym (extroduce_lgti (mkilist l1) i)) (succ i')).
-     apply decode_Fin_unique.
-     do 2 rewrite <- decode_Fin_match'.
-     simpl.
-     rewrite <- decode_Fin_match'.
-     reflexivity.
-     rewrite H4.
-     apply H1'.
-     
-     rewrite extroduce_ok2' ; try assumption.
-     rewrite (decode_Fin_match' i' h2) in a.
-     rewrite extroduce_ok2' ; try assumption.
-     assert (H4 : rewriteFins (Logic.eq_sym (extroduce_lgti (mkilist l2) i)) (weakFin (rewriteFins h2 i')) = 
-       rewriteFins (eq_sym (extroduce_lgti (mkilist l1) i)) (weakFin i')).
-     apply decode_Fin_unique.
-     do 2 rewrite <- decode_Fin_match'.
-     do 2 rewrite weakFin_ok.
-     rewrite <- decode_Fin_match'.
-     reflexivity.
-     rewrite H4.
-     apply H1'.
+     - rewrite extroduce_ok3' ; try assumption.
+       rewrite (decode_Fin_match' i' h2) in a.
+       rewrite extroduce_ok3' ; try assumption.
+       assert (H4 : rewriteFins (Logic.eq_sym (extroduce_lgti (mkilist l2) i)) (succ (rewriteFins h2 i')) = 
+                    rewriteFins (eq_sym (extroduce_lgti (mkilist l1) i)) (succ i')).
+       { apply decode_Fin_unique.
+         do 2 rewrite <- decode_Fin_match'.
+         cbn.
+         rewrite <- decode_Fin_match'.
+         reflexivity. }
+       rewrite H4.
+       apply H1'.
+     - rewrite extroduce_ok2' ; try assumption.
+       rewrite (decode_Fin_match' i' h2) in a.
+       rewrite extroduce_ok2' ; try assumption.
+       assert (H4 : rewriteFins (Logic.eq_sym (extroduce_lgti (mkilist l2) i)) (weakFin (rewriteFins h2 i')) = 
+                    rewriteFins (eq_sym (extroduce_lgti (mkilist l1) i)) (weakFin i')).
+       { apply decode_Fin_unique.
+         do 2 rewrite <- decode_Fin_match'.
+         do 2 rewrite weakFin_ok.
+         rewrite <- decode_Fin_match'.
+         reflexivity. }
+       rewrite H4.
+       apply H1'.
    Qed.
 
    Lemma extroduce_ilist_rel_bis (T: Set)(RelT: relation T)(l1 l2 : ilist T)
@@ -290,7 +279,7 @@ Set Implicit Arguments.
      ilist_rel RelT (extroduce l1 i) (extroduce l2 (rewriteFins h i)).
    Proof.
      destruct l1 as [n l1] ; destruct l2 as [n2 l2].
-     simpl in i, h.
+     cbn in i, h.
      revert l2 ; rewrite <- h ; clear n2 h ; intros l2 h.
      apply extroduce_ilist_rel, h.
    Qed.
@@ -302,51 +291,49 @@ Set Implicit Arguments.
      destruct l1 as [n l1].
      destruct l2 as [n' l2].
      assert (ii := ilist_rel_lgti Hyp).
-     simpl in ii.
+     cbn in ii.
      revert l2 Hyp.
      rewrite <- ii.
      clear ii.
      intros.
      assert (rewriteFins (ilist_rel_lgti Hyp) i = i).
-     treatFinPure.
-     
-     rewrite H.
-     apply extroduce_ilist_rel.
-     assumption.
+     - treatFinPure.
+     - rewrite H.
+       apply extroduce_ilist_rel.
+       assumption.
    Qed.
 
    Lemma extroduce_imap (T U: Set)(f: T -> U)(l: ilist T)(i: Fin (lgti l)): 
      ilist_rel eq (extroduce (imap f l) i) (imap f (extroduce l i)).
    Proof.
      assert (h: lgti (extroduce (imap f l) i) =  lgti (imap f (extroduce l i))).
-     apply eq_add_S.
-     do 2 rewrite imap_lgti, <- extroduce_lgti.
-     reflexivity.
+     { apply eq_add_S.
+       do 2 rewrite imap_lgti, <- extroduce_lgti.
+       reflexivity. }
      apply (is_ilist_rel _ _ _  h).
      intro i'.
      rewrite imap_apply. 
      elim (le_lt_dec (decode_Fin i) (decode_Fin i')); intros a.
-     rewrite extroduce_ok3'; try assumption.
-     rewrite imap_apply.
-     rewrite extroduce_ok3'.
-     repeat f_equal.
-     treatFinPure.
-     rewrite <- decode_Fin_match' ; assumption.
-
-     rewrite extroduce_ok2' ; try assumption.
-     rewrite imap_apply.
-     rewrite extroduce_ok2'.
-     repeat f_equal.
-     treatFinPure.
-     rewrite <- decode_Fin_match' ; assumption.
+     - rewrite extroduce_ok3'; try assumption.
+       rewrite imap_apply.
+       rewrite extroduce_ok3'.
+       + repeat f_equal.
+         treatFinPure.
+       + rewrite <- decode_Fin_match' ; assumption.
+     - rewrite extroduce_ok2' ; try assumption.
+       rewrite imap_apply.
+       rewrite extroduce_ok2'.
+       + repeat f_equal.
+         treatFinPure.
+       + rewrite <- decode_Fin_match' ; assumption.
    Qed.
 
    Definition extroduce_Fin : forall (n: nat)(fex: Fin (S n))(f: Fin n), Fin (S n).
    Proof.
      intros n fex f.
      elim (le_lt_dec (decode_Fin fex) (decode_Fin f)) ; intros a.
-     exact (succ f).
-     exact (weakFin f).
+     - exact (succ f).
+     - exact (weakFin f).
    Defined.
 
    Lemma extroduce_Fin_not_fex (n: nat)(fex: Fin (S n))(f: Fin n):
@@ -355,16 +342,16 @@ Set Implicit Arguments.
      intros.
      unfold extroduce_Fin; unfold sumbool_rec; unfold sumbool_rect.
      elim (le_lt_dec (decode_Fin fex) (decode_Fin f)) ; intros a; intro Hyp.
-     rewrite <- Hyp in a.
-     simpl in a.
-     apply le_Sn_n in a.
-     assumption.
-     assert (H: decode_Fin (weakFin f) = decode_Fin fex).
-     rewrite Hyp.
-     reflexivity.
-     evalDecode_Fin_Ass H.
-     rewrite H in a.
-     exact (lt_irrefl _ a).
+     - rewrite <- Hyp in a.
+       cbn in a.
+       apply le_Sn_n in a.
+       assumption.
+     - assert (H: decode_Fin (weakFin f) = decode_Fin fex).
+       { rewrite Hyp.
+         reflexivity. }
+       evalDecode_Fin_Ass H.
+       rewrite H in a.
+       exact (lt_irrefl _ a).
    Qed.
 
    Lemma extroduce_lgti_S: forall (T: Set) (n: nat) (i: ilistn T (S n)) (f: Fin(S n)), 
@@ -385,16 +372,16 @@ Set Implicit Arguments.
      unfold extroduce_Fin.
      unfold sumbool_rec ; unfold sumbool_rect.
      elim (le_lt_dec (decode_Fin fex) (decode_Fin f)) ; intros a.
-     assert (h: decode_Fin fex <= 
+     - assert (h: decode_Fin fex <= 
        decode_Fin (rewriteFins (@extroduce_lgti_S T n i fex) f)).
-     treatFin a.
-     rewrite extroduce_ok3'; try assumption.
-     apply (fRel EqT).
-     treatFinPure.
-     rewrite extroduce_ok2'; try assumption.
-     apply (fRel EqT).
-     treatFinPure.
-     treatFinAss.
+       { treatFin a. }
+       rewrite extroduce_ok3'; try assumption.
+       apply (fRel EqT).
+       treatFinPure.
+     - rewrite extroduce_ok2'; try assumption.
+       + apply (fRel EqT).
+         treatFinPure.
+       + treatFinAss.
    Qed.
   
    Corollary extroduce_Fin_ok_cor (T: Set)(n: nat)(i: ilistn T (S n))(fex: Fin (S n))(f: Fin n): 
@@ -411,8 +398,8 @@ Set Implicit Arguments.
    Proof.
      unfold extroduce_Fin, sumbool_rec, sumbool_rect.
      elim (le_lt_dec (decode_Fin iex) (decode_Fin i)) ; intros a.
-     reflexivity.
-     apply False_rec, (lt_irrefl _ (lt_le_trans _ _ _ a h)).
+     - reflexivity.
+     - apply False_rec, (lt_irrefl _ (lt_le_trans _ _ _ a h)).
    Qed.
 
    Lemma extroduce_Fin_ok2  (n: nat)(iex: Fin (S n))(i: Fin n) (h: decode_Fin i < decode_Fin iex): 
@@ -420,8 +407,8 @@ Set Implicit Arguments.
    Proof.
      unfold extroduce_Fin, sumbool_rec, sumbool_rect.
      elim (le_lt_dec (decode_Fin iex) (decode_Fin i)) ; intros a.
-     apply False_rec, (lt_irrefl _ (lt_le_trans _ _ _ h a)).
-     reflexivity.
+     - apply False_rec, (lt_irrefl _ (lt_le_trans _ _ _ h a)).
+     - reflexivity.
    Qed.
 
    Definition index_in_extroduce (n: nat)(fex: Fin (S n))(f: Fin (S n)): 
@@ -429,13 +416,13 @@ Set Implicit Arguments.
    Proof.
      intros.
      elim (lt_eq_lt_dec  (decode_Fin fex) (decode_Fin f)) ; intros a.
-     destruct a as [a|a].
-     exact (get_cons f (lt_n_m_0 a)).
-     (* idea: f is a successor, hence one can take its predecessor in Fin n *)
-     apply False_rec.
-     exact (H a).
-     exact (code_Fin1 (lt_le_trans _ _ _ a (lt_n_Sm_le _ _ (decode_Fin_inf_n fex)))).
-     (* idea: f < fex, hence f(!) can be strenghtened to be in Fin n *)
+     - destruct a as [a|a].
+       + exact (get_cons f (lt_n_m_0 a)).
+         (* idea: f is a successor, hence one can take its predecessor in Fin n *)
+       + apply False_rec.
+         exact (H a).
+     - exact (code_Fin1 (lt_le_trans _ _ _ a (lt_n_Sm_le _ _ (decode_Fin_inf_n fex)))).
+       (* idea: f < fex, hence f(!) can be strenghtened to be in Fin n *)
    Defined.
 
    Lemma index_in_extroduce_decode1 (n: nat)(fex: Fin (S n))(f: Fin (S n))(Hyp1:
@@ -446,12 +433,12 @@ Set Implicit Arguments.
      unfold index_in_extroduce.
      unfold sumor_rec ; unfold sumor_rect.
      elim (lt_eq_lt_dec  (decode_Fin fex) (decode_Fin f)) ; intros a.
-     destruct a as [a|a].
-     treatFinPure.
-     apply False_rec.
-     apply (Hyp1 a).
-     apply False_rec.
-     apply (lt_asym _ _ a Hyp2).
+     - destruct a as [a|a].
+       + treatFinPure.
+       + apply False_rec.
+         apply (Hyp1 a).
+     - apply False_rec.
+       apply (lt_asym _ _ a Hyp2).
    Qed.
 
    Lemma index_in_extroduce_decode2 (n: nat)(fex: Fin (S n))(f: Fin (S n))(Hyp1:
@@ -462,12 +449,12 @@ Set Implicit Arguments.
      unfold index_in_extroduce.
      unfold sumor_rec ; unfold sumor_rect.
      elim (lt_eq_lt_dec  (decode_Fin fex) (decode_Fin f)) ; intros a.
-     destruct a as [a|a].
-     apply False_rec.
-     apply (lt_asym _ _ a Hyp2).
-     apply False_rec.
-     apply (Hyp1 a).
-     treatFinPure.
+     - destruct a as [a|a].
+       + apply False_rec.
+         apply (lt_asym _ _ a Hyp2).
+       + apply False_rec.
+         apply (Hyp1 a).
+     - treatFinPure.
    Qed.
     
    Lemma index_in_extroduce_decode3 (n: nat)(fex: Fin (S n))(f: Fin (S n))(Hyp1:
@@ -475,14 +462,14 @@ Set Implicit Arguments.
    Proof.
      intros.
      elim (lt_eq_lt_dec  (decode_Fin fex) (decode_Fin f)) ; intros a.
-     destruct a as [a|a].
-     rewrite <- (index_in_extroduce_decode1 fex f Hyp1 a).
-     auto.
-     apply False_rec.
-     apply (Hyp1 a).
-     rewrite index_in_extroduce_decode2.
-     auto.
-     assumption.
+     - destruct a as [a|a].
+       + rewrite <- (index_in_extroduce_decode1 fex f Hyp1 a).
+         auto.
+       + apply False_rec.
+         apply (Hyp1 a).
+     - rewrite index_in_extroduce_decode2.
+       + auto.
+       + assumption.
    Qed.
     
    Lemma index_in_extroduce_decode4 (n: nat)(fex: Fin (S n))(f: Fin (S n))(Hyp1:
@@ -509,16 +496,16 @@ Set Implicit Arguments.
      unfold index_in_extroduce.
      unfold sumor_rec ; unfold sumor_rect.
      elim (lt_eq_lt_dec  (decode_Fin fex) (decode_Fin f)) ; try intros [a|a] ; try intros a.
-     rewrite (extroduce_ok3' (mkilist i)).
-     apply (fRel EqT).
-     treatFinPure.
-     treatFinAss.
-     apply False_rec.
-     exact (H a).
-     rewrite (extroduce_ok2' (mkilist i)).
-     apply (fRel EqT).
-     treatFinAss.
-     treatFinAss.
+     - rewrite (extroduce_ok3' (mkilist i)).
+       + apply (fRel EqT).
+         treatFinPure.
+       + treatFinAss.
+     - apply False_rec.
+       exact (H a).
+     - rewrite (extroduce_ok2' (mkilist i)).
+       + apply (fRel EqT).
+         treatFinAss.
+       + treatFinAss.
    Qed.
     
    Corollary index_in_extroduce_ok_cor (T: Set)(n: nat)(i: ilistn T (S n))(fex: Fin (S n))(f: Fin (S n))
@@ -555,31 +542,31 @@ Set Implicit Arguments.
      unfold index_in_extroduce.
      unfold sumor_rec ; unfold sumor_rect.
      elim (lt_eq_lt_dec  (decode_Fin(rewriteFins (sym_eq Hyp) fex)) (decode_Fin f)) ; intros a.
-     destruct a as [a|a].
-     set (fnew := get_cons f (lt_n_m_0 a)).
-     assert (fnew_ok: decode_Fin f = S (decode_Fin fnew)).
-     unfold fnew.
-     treatFinPure.
-     rewrite (extroduce_ok3' (mkilist i)).
-     apply (fRel EqT).
-     treatFinAss.
-     evalDecode_Fin.
-     apply lt_n_Sm_le.
-     rewrite <- fnew_ok.
-     treatFin a.
-     apply False_rec.
-     exact (H a).
-     set (fnew := code_Fin1 (lt_le_trans _ _ _ a (lt_n_Sm_le _ _ 
-       (decode_Fin_inf_n (rewriteFins (sym_eq Hyp) fex))))).
-     assert (fnew_ok: decode_Fin f = decode_Fin fnew).
-     unfold fnew.
-     treatFinPure.
-     rewrite (extroduce_ok2' (mkilist i)).
-     apply (fRel EqT).
-     treatFinAss.
-     evalDecode_Fin.
-     rewrite <- fnew_ok.
-     treatFin a.
+     - destruct a as [a|a].
+       + set (fnew := get_cons f (lt_n_m_0 a)).
+         assert (fnew_ok: decode_Fin f = S (decode_Fin fnew)).
+         { unfold fnew.
+           treatFinPure. }
+         rewrite (extroduce_ok3' (mkilist i)).
+         * apply (fRel EqT).
+           treatFinAss.
+         * evalDecode_Fin.
+           apply lt_n_Sm_le.
+           rewrite <- fnew_ok.
+           treatFin a.
+       + apply False_rec.
+         exact (H a).
+     - set (fnew := code_Fin1 (lt_le_trans _ _ _ a (lt_n_Sm_le _ _ 
+         (decode_Fin_inf_n (rewriteFins (sym_eq Hyp) fex))))).
+       assert (fnew_ok: decode_Fin f = decode_Fin fnew).
+       { unfold fnew.
+         treatFinPure. }
+       rewrite (extroduce_ok2' (mkilist i)).
+       + apply (fRel EqT).
+         treatFinAss.
+       + evalDecode_Fin.
+         rewrite <- fnew_ok.
+         treatFin a.
    Qed.
 
    Corollary index_in_extroduce_ok'_cor (T: Set)(n: nat)(i: ilist T)(Hyp: S n = lgti i)(fex: Fin (lgti i))
@@ -598,12 +585,12 @@ Set Implicit Arguments.
    Proof. 
      apply decode_Fin_unique. 
      elim (lt_eq_lt_dec (decode_Fin i1) (decode_Fin i2)) ; try intros [d|d] ; try intros d.
-     apply eq_add_S.
-     rewrite index_in_extroduce_decode1, index_in_extroduce_decode1 ; try assumption.
-     reflexivity.
-     contradiction h1.
-     rewrite index_in_extroduce_decode2, index_in_extroduce_decode2 ; try assumption.
-     reflexivity.
+     - apply eq_add_S.
+       rewrite index_in_extroduce_decode1, index_in_extroduce_decode1 ; try assumption.
+       reflexivity.
+     - contradiction h1.
+     - rewrite index_in_extroduce_decode2, index_in_extroduce_decode2 ; try assumption.
+       reflexivity.
    Qed.
 
    Lemma index_in_extroduce_weakFin (n: nat) (i1: Fin (S n)) (i2: Fin n)(h: decode_Fin i1 <> decode_Fin (weakFin i2)): 
@@ -621,11 +608,11 @@ Set Implicit Arguments.
    Proof.
      intros h2.
      apply decode_Fin_unique.
-     simpl.
+     cbn.
      apply index_in_extroduce_decode1.
      destruct (le_lt_or_eq _ _ (le_trans _ _ _ h2 (index_in_extroduce_decode3 i1 i2 a)))  as [e|e].
-     assumption.
-     contradiction e.
+     - assumption.
+     - contradiction e.
    Qed. 
 
    Lemma index_in_extroduce_weakFin2 (n: nat)(i1 i2: Fin (S n))(a : decode_Fin i1 <> decode_Fin i2) : 
@@ -636,9 +623,9 @@ Set Implicit Arguments.
      rewrite weakFin_ok.
      apply index_in_extroduce_decode2.
      destruct (le_lt_or_eq _ _ (le_trans _ _ _ (index_in_extroduce_decode4 i1 i2 a) (lt_le_S _ _ h2)))  as [e|e].
-     assumption.
-     contradiction a.
-     symmetry ; assumption.
+     - assumption.
+     - contradiction a.
+       symmetry ; assumption.
    Qed. 
    
    Lemma index_in_extroduce_succ2 (n: nat) (i1: Fin (S n)) (i2: Fin n)(h: decode_Fin i1 <> decode_Fin (succ i2)): 
@@ -656,14 +643,13 @@ Set Implicit Arguments.
    Proof.
      apply decode_Fin_unique.
      elim (not_eq _ _ h) ; intros a.
-     rewrite extroduce_Fin_ok1.
-     apply index_in_extroduce_decode1 ; try assumption.
-     apply gt_S_le.
-     rewrite index_in_extroduce_decode1; assumption.
-     
-     rewrite extroduce_Fin_ok2, weakFin_ok.
-     apply index_in_extroduce_decode2 ; try assumption.
-     rewrite index_in_extroduce_decode2; assumption.
+     - rewrite extroduce_Fin_ok1.
+       + apply index_in_extroduce_decode1 ; try assumption.
+       + apply gt_S_le.
+         rewrite index_in_extroduce_decode1; assumption.
+     - rewrite extroduce_Fin_ok2, weakFin_ok.
+       + apply index_in_extroduce_decode2 ; try assumption.
+       + rewrite index_in_extroduce_decode2; assumption.
    Qed.
   
    Lemma decode_Fin_extroduce_Fin_neq (n: nat)(iex: Fin (S n))(i: Fin n): 
@@ -671,28 +657,27 @@ Set Implicit Arguments.
    Proof.
      unfold extroduce_Fin, sumbool_rec, sumbool_rect.
      elim (le_lt_dec (decode_Fin iex) (decode_Fin i)) ; intros a h ; rewrite h in a.
-     apply (le_Sn_n _ a).
-     rewrite weakFin_ok in a.
-     apply (lt_irrefl _ a).
+     - apply (le_Sn_n _ a).
+     - rewrite weakFin_ok in a.
+       apply (lt_irrefl _ a).
    Defined.
 
    Lemma index_in_from_extroduce (n: nat)(iex: Fin (S n))(i: Fin n)
      (h: decode_Fin iex <> decode_Fin (extroduce_Fin iex i)) : index_in_extroduce _ _ h = i.
    Proof.
      revert h ; elim (le_lt_dec (decode_Fin iex) (decode_Fin i)) ; intros a.
-     rewrite extroduce_Fin_ok1 ; try assumption.
-     intros h.
-     apply decode_Fin_unique, eq_add_S.
-     apply index_in_extroduce_decode1.
-     apply le_lt_n_Sm, a.
-     
-     rewrite extroduce_Fin_ok2 ; try assumption.
-     intros h.
-     apply decode_Fin_unique.
-     rewrite index_in_extroduce_decode2.
-     apply weakFin_ok.
-     rewrite weakFin_ok.
-     assumption.
+     - rewrite extroduce_Fin_ok1 ; try assumption.
+       intros h.
+       apply decode_Fin_unique, eq_add_S.
+       apply index_in_extroduce_decode1.
+       apply le_lt_n_Sm, a.
+     - rewrite extroduce_Fin_ok2 ; try assumption.
+       intros h.
+       apply decode_Fin_unique.
+       rewrite index_in_extroduce_decode2.
+       + apply weakFin_ok.
+       + rewrite weakFin_ok.
+         assumption.
    Qed.
 
    Lemma extroduce_interchange_aux (T : Set)(n : nat)(i : ilistn T (S n))
@@ -708,6 +693,7 @@ Set Implicit Arguments.
    Qed.
 
    Require Import Lia.
+   
    Definition extroduce_interchange_statement_eq: Prop :=
      forall (T : Set)(n : nat)(i : ilistn T (S n))
        (f f': Fin (S n))(a : decode_Fin f <> decode_Fin f')(a' : decode_Fin f' <> decode_Fin f),
@@ -787,38 +773,37 @@ Set Implicit Arguments.
       ilist_rel eq (iappend (left_sib l i) (right_sib l i)) (extroduce l i).
     Proof.
       assert (h : lgti (iappend (left_sib l i) (right_sib l i)) = lgti (extroduce l i)).
-      rewrite iappend_lgti.
-      apply eq_add_S.
-      rewrite left_sib_right_sib_lgti.
-      apply extroduce_lgti.
+      { rewrite iappend_lgti.
+        apply eq_add_S.
+        rewrite left_sib_right_sib_lgti.
+        apply extroduce_lgti. }
       apply (is_ilist_rel _ _ _ h).
       intros i'.
       elim (le_lt_dec (decode_Fin i) (decode_Fin (rewriteFins h i'))) ; intros a.
-      rewrite extroduce_ok3' ; try assumption.
-      rewrite <- (left_sib_lgti l i) in a.
-      rewrite <- decode_Fin_match', (decode_Fin_match' i' (iappend_lgti (left_sib l i) (right_sib l i))) in a.
-      rewrite (iappend_right _ _ _ a).
-      simpl .
-      f_equal.
-      apply decode_Fin_unique.
-      unfold rightFin.
-      do 2 rewrite decode_code1_Id.
-      rewrite le_plus_minus_r ; try assumption.
-      do 2 rewrite <- decode_Fin_match'.
-      simpl.
-      rewrite <- decode_Fin_match'.
-      reflexivity.
-      
-      rewrite extroduce_ok2'; try assumption.
-      rewrite <- (left_sib_lgti l i), <- decode_Fin_match' in a.
-      rewrite (iappend_left _ _ _ a).
-      simpl fcti at 1.
-      f_equal.
-      apply decode_Fin_unique.
-      do 2 rewrite decode_code1_Id.
-      rewrite <- decode_Fin_match'.
-      rewrite weakFin_ok.
-      apply decode_Fin_match'.
+      - rewrite extroduce_ok3' ; try assumption.
+        rewrite <- (left_sib_lgti l i) in a.
+        rewrite <- decode_Fin_match', (decode_Fin_match' i' (iappend_lgti (left_sib l i) (right_sib l i))) in a.
+        rewrite (iappend_right _ _ _ a).
+        cbn.
+        f_equal.
+        apply decode_Fin_unique.
+        unfold rightFin.
+        do 2 rewrite decode_code1_Id.
+        rewrite le_plus_minus_r ; try assumption.
+        do 2 rewrite <- decode_Fin_match'.
+        cbn.
+        rewrite <- decode_Fin_match'.
+        reflexivity.
+      - rewrite extroduce_ok2'; try assumption.
+        rewrite <- (left_sib_lgti l i), <- decode_Fin_match' in a.
+        rewrite (iappend_left _ _ _ a).
+        simpl fcti at 1.
+        f_equal.
+        apply decode_Fin_unique.
+        do 2 rewrite decode_code1_Id.
+        rewrite <- decode_Fin_match'.
+        rewrite weakFin_ok.
+        apply decode_Fin_match'.
     Qed.
     
     Lemma left_right_sib_extroduce_bis (T: Set)(l : ilist T)(i: Fin (lgti l)): 
@@ -829,8 +814,8 @@ Set Implicit Arguments.
       unfold ilist2list.
       assert (H3 : makeListFin (lgti (extroduce l i)) = map (rewriteFins H1) 
       (makeListFin (lgti (iappend (left_sib l i) (right_sib l i))))).
-      rewrite <- H1.
-      apply sym_eq, map_id.
+      { rewrite <- H1.
+        apply sym_eq, map_id. }
       rewrite H3.
       rewrite map_map.
       apply map_ext.

--- a/Fin.v
+++ b/Fin.v
@@ -47,7 +47,7 @@ Section Fin_def_tools.
   Lemma Fin_S_pred : forall n: nat, n > 0 -> Fin n = Fin (S (pred n)).
   Proof.
     intros n h.
-    rewrite <-(S_pred n 0 h). 
+    rewrite <- (S_pred n 0 h). 
     reflexivity.
   Qed.    
 
@@ -61,8 +61,8 @@ Section Fin_def_tools.
   Proof.
     intros n f.
     induction f as [ n | n f IHf].
-    apply gt_Sn_O.
-    apply (gt_n_S _ _ IHf).
+    - apply gt_Sn_O.
+    - apply (gt_n_S _ _ IHf).
   Defined.
 
   Definition decode_Fin_S_gt_O: 
@@ -102,14 +102,14 @@ Section Fin_def_tools.
   Definition code_fin1_aux_def: forall n m: nat, m <= n -> 
     {f: Fin (S n) & code_Fin1_aux n m = Some f}.
   Proof.
-    induction n as [ | n IHn]; intros m H ; destruct m as [ | m]; simpl.
-    exists (first 0); reflexivity.
-    destruct (le_Sn_O m H).
-    exists (first (S n)); reflexivity.
-    destruct (IHn m (le_S_n _ _ H)) as [f0 eq].
-    exists (succ f0).
-    rewrite eq.
-    reflexivity.
+    induction n as [ | n IHn]; intros m H ; destruct m as [ | m]; cbn.
+    - exists (first 0); reflexivity.
+    - destruct (le_Sn_O m H).
+    - exists (first (S n)); reflexivity.
+    - destruct (IHn m (le_S_n _ _ H)) as [f0 eq].
+      exists (succ f0).
+      rewrite eq.
+      reflexivity.
   Defined.
 
   Definition code_Fin1_Sn (n m: nat)(h: m<=n): Fin (S n) := 
@@ -147,13 +147,13 @@ Section Fin_def_tools.
     intros n m.
     revert n.
     induction m as [ | m IHm]; intros n h1 h2.
-    do 2 rewrite code_Fin1_Sn_0.
-    reflexivity.
-    destruct n as [ | n].
-    inversion h1.
-    do 2 rewrite code_Fin1_Sn_S.
-    f_equal.
-    apply IHm.
+    - do 2 rewrite code_Fin1_Sn_0.
+      reflexivity.
+    - destruct n as [ | n].
+      + inversion h1.
+      + do 2 rewrite code_Fin1_Sn_S.
+        f_equal.
+        apply IHm.
   Qed.
 
   Lemma code_Fin1_Sn_proofirr2 : forall (n m1 m2:nat)(h1:m1<=n)(h2:m2<=n)(e: m1=m2),
@@ -162,18 +162,18 @@ Section Fin_def_tools.
     induction n as [| n IHn]; 
     intros m1 m2 h1 h2 e;
     destruct m1 as [|m1]; destruct m2 as [|m2].
-    do 2 rewrite code_Fin1_Sn_0.
-    reflexivity.
-    destruct (O_S m2 e).
-    destruct (O_S m1 (sym_eq e)).
-    inversion h1.
-    do 2 rewrite code_Fin1_Sn_0.
-    reflexivity.
-    destruct (O_S m2 e).
-    destruct (O_S m1 (sym_eq e)).
-    do 2 rewrite code_Fin1_Sn_S.
-    f_equal.
-    apply (IHn _ _ _ _ (eq_add_S m1 m2 e)).
+    - do 2 rewrite code_Fin1_Sn_0.
+      reflexivity.
+    - destruct (O_S m2 e).
+    - destruct (O_S m1 (sym_eq e)).
+    - inversion h1.
+    - do 2 rewrite code_Fin1_Sn_0.
+      reflexivity.
+    - destruct (O_S m2 e).
+    - destruct (O_S m1 (sym_eq e)).
+    - do 2 rewrite code_Fin1_Sn_S.
+      f_equal.
+      apply (IHn _ _ _ _ (eq_add_S m1 m2 e)).
   Qed.
 
   Lemma code_Fin1_0_: forall (n:nat)(h:0<S n), code_Fin1 h = first n.
@@ -187,12 +187,12 @@ Section Fin_def_tools.
   Proof.
     intros n m h.
     destruct n as [|n].
-    apply False_rec.
-    apply (le_Sn_O _ (gt_S_le _ _ h)).
-    simpl.
-    rewrite code_Fin1_Sn_S.
-    f_equal.
-    apply code_Fin1_Sn_proofirr.
+    - apply False_rec.
+      apply (le_Sn_O _ (gt_S_le _ _ h)).
+    - cbn.
+      rewrite code_Fin1_Sn_S.
+      f_equal.
+      apply code_Fin1_Sn_proofirr.
   Qed.
 
   Lemma code_Fin1_proofirr : forall (n m:nat)(h1 h2:m< S n),
@@ -213,15 +213,15 @@ Section Fin_def_tools.
     intros f Hyp0 HypS.
     induction n as [|n IHn]; 
     intros m h.
-    inversion h.
-    induction m as [|m IHm].
-    rewrite Hyp0.
-    rewrite code_Fin1_0_.
-    reflexivity.
-    rewrite HypS.
-    rewrite code_Fin1_S.
-    f_equal.
-    apply IHn.
+    - inversion h.
+    - induction m as [|m IHm].
+      + rewrite Hyp0.
+        rewrite code_Fin1_0_.
+        reflexivity.
+      + rewrite HypS.
+        rewrite code_Fin1_S.
+        f_equal.
+        apply IHn.
   Qed.
 
   Lemma Fin_0_empty: forall f: Fin 0, False.
@@ -235,11 +235,10 @@ Section Fin_def_tools.
   Proof.
     induction n as [|n IHn];
     intros m h.
-    apply False_rec; apply (lt_n_O _ h).
-
-    destruct m as [| m].
-    exact (first n).
-    exact (succ (IHn m (lt_S_n m n h))).
+    - apply False_rec; apply (lt_n_O _ h).
+    - destruct m as [| m].
+      + exact (first n).
+      + exact (succ (IHn m (lt_S_n m n h))).
   Defined. 
 
   (* We prove the lemmas needed to be able to apply code_Fin1_char in order
@@ -261,35 +260,34 @@ Section Fin_def_tools.
     intros n m.
     revert n.
     induction m as [|m IHm]; intros n h1 h2.
-    reflexivity.
-    destruct n as [|n].
-    apply False_rec.
-    apply (le_Sn_O _ (gt_S_le _ _ h1)).
-    do 2 rewrite code_Fin2_S.
-    f_equal.
-    apply IHm.
+    - reflexivity.
+    - destruct n as [|n].
+      + apply False_rec.
+        apply (le_Sn_O _ (gt_S_le _ _ h1)).
+      + do 2 rewrite code_Fin2_S.
+        f_equal.
+        apply IHm.
   Qed.
 
   (* We finally prove that code_Fin1 = code_Fin2 *)
   Lemma code1_code2_eq: forall (n m: nat)(h:m<n), code_Fin1 h = code_Fin2 h.
   Proof.
     induction n as [|n IHn].
-    inversion h.
-    destruct m as [|m]; intro h.
-    rewrite (code_Fin2_0 h).
-    simpl.
-    rewrite code_Fin1_Sn_0.
-    reflexivity.
-
-    rewrite (code_Fin2_S h).
-    simpl.
-    destruct n as [|n].
-    apply False_rec.
-    apply (le_Sn_O _ (gt_S_le _ _ h)).
-    rewrite code_Fin1_Sn_S.
-    f_equal.
-    rewrite <- (IHn m (lt_S_n m (S n) h)).
-    apply code_Fin1_Sn_proofirr.
+    - inversion h.
+    - destruct m as [|m]; intro h.
+      + rewrite (code_Fin2_0 h).
+        cbn.
+        rewrite code_Fin1_Sn_0.
+        reflexivity.
+      + rewrite (code_Fin2_S h).
+        cbn.
+        destruct n as [|n].
+        * apply False_rec.
+          apply (le_Sn_O _ (gt_S_le _ _ h)).
+        * rewrite code_Fin1_Sn_S.
+          f_equal.
+          rewrite <- (IHn m (lt_S_n m (S n) h)).
+          apply code_Fin1_Sn_proofirr.
   Qed.
   
   (* Alternative proof using code_Fin1_char *)
@@ -305,39 +303,38 @@ Section Fin_def_tools.
   Lemma code1_decode_Id: forall (n: nat)(f: Fin n), 
     (code_Fin1 (decode_Fin_inf_n f)) = f.
   Proof.
-    induction f as [k | k f IHf]; simpl.
-    rewrite code_Fin1_Sn_0; reflexivity.
-    destruct k as [|k].
-    inversion f.
-    rewrite code_Fin1_Sn_S.
-    f_equal.
-    transitivity (code_Fin1_Sn
+    induction f as [k | k f IHf]; cbn.
+    - rewrite code_Fin1_Sn_0; reflexivity.
+    - destruct k as [|k].
+      + inversion f.
+      + rewrite code_Fin1_Sn_S.
+        f_equal.
+        transitivity (code_Fin1_Sn
         (lt_n_Sm_le (decode_Fin f) k (decode_Fin_inf_n f))); try assumption.
-    apply code_Fin1_Sn_proofirr.
+        apply code_Fin1_Sn_proofirr.
   Qed.
 
   Lemma decode_code1_Id: forall (n m: nat)(h: m < n), 
     decode_Fin (code_Fin1 h) = m.
   Proof.
     induction n as [|n IHn].
-    inversion h.
-    unfold code_Fin1.
-    destruct m as [|m]. 
-    inversion h ; 
-    rewrite code_Fin1_Sn_0 ;
-    reflexivity.
-    
-    destruct n as [|n];
-    intro h.
-    apply False_rec.
-    apply (le_Sn_O _ (gt_S_le _ _ h)).
-    rewrite code_Fin1_Sn_S.
-    simpl.
-    f_equal.
-    rewrite (code_Fin1_Sn_proofirr 
-      (le_S_n m n (lt_n_Sm_le (S m) (S n) h)) 
-                  (lt_n_Sm_le m n (lt_S_n m (S n) h))).
-    apply (IHn m (lt_S_n m (S n) h)).
+    - inversion h.
+    - unfold code_Fin1.
+      destruct m as [|m]. 
+      + inversion h ; 
+          rewrite code_Fin1_Sn_0 ;
+          reflexivity.
+      + destruct n as [|n];
+          intro h.
+        * apply False_rec.
+          apply (le_Sn_O _ (gt_S_le _ _ h)).
+        * rewrite code_Fin1_Sn_S.
+          cbn.
+          f_equal.
+          rewrite (code_Fin1_Sn_proofirr 
+                     (le_S_n m n (lt_n_Sm_le (S m) (S n) h)) 
+                     (lt_n_Sm_le m n (lt_S_n m (S n) h))).
+          apply (IHn m (lt_S_n m (S n) h)).
   Qed.
 
   (* Third definition of code_Fin *)
@@ -346,21 +343,19 @@ Section Fin_def_tools.
   Proof.
     induction n as [|n IHn]; 
     intros x h.
-    apply False_rec; inversion h.
-    
-    elim (lt_eq_lt_dec x n) ; intros a.
-    clear h.
-    inversion_clear a as [H | H].
-    assert (H0 := IHn x H).
-    exact (succ H0).
-    exact (first n).
-    
-    apply False_rec.
-    inversion h as [e | y irr].
-    rewrite e in a.
-    apply (lt_irrefl _ a).
-    apply (lt_irrefl x (lt_trans x (S x) x (lt_n_Sn x)
-                                        (le_lt_trans (S x) n x irr a))).
+    - apply False_rec; inversion h.
+    - elim (lt_eq_lt_dec x n) ; intros a.
+      + clear h.
+        inversion_clear a as [H | H].
+        * assert (H0 := IHn x H).
+          exact (succ H0).
+        * exact (first n).
+      + apply False_rec.
+        inversion h as [e | y irr].
+        * rewrite e in a.
+          apply (lt_irrefl _ a).
+        * apply (lt_irrefl x (lt_trans x (S x) x (lt_n_Sn x)
+                                       (le_lt_trans (S x) n x irr a))).
   Defined.
 
   (* Proof of lemmmas on the auxiliary definition *)
@@ -372,13 +367,13 @@ Section Fin_def_tools.
     code_Fin3_aux (lt_n_Sn n) = first n.
   Proof.
     intros n.
-    simpl.
+    cbn.
     unfold sumor_rec ; unfold sumor_rect.
     elim (lt_eq_lt_dec n n); intro a.
     destruct a as [H | _].
     apply False_rec; apply (lt_irrefl n H).
-    reflexivity.
-    apply False_rec; apply (lt_irrefl n a).
+    - reflexivity.
+    - apply False_rec; apply (lt_irrefl n a).
   Qed.
 
   Lemma code_Fin3_aux_0: forall (n:nat)(h:0< S n),
@@ -386,16 +381,16 @@ Section Fin_def_tools.
   Proof.
     intros n h.
     induction n as [|n IHn].
-    reflexivity.
-    simpl.
-    simpl in IHn.
-    rewrite IHn.
-    f_equal.
-    elim n.
-    reflexivity.
-    intros n0 _.
-    f_equal.
-    apply code_Fin2_proofirr.
+    - reflexivity.
+    - cbn.
+      cbn in IHn.
+      rewrite IHn.
+      f_equal.
+      elim n.
+      + reflexivity.
+      + intros n0 _.
+        f_equal.
+        apply code_Fin2_proofirr.
   Qed.
  
   Lemma code_Fin3_aux_S : forall (m n:nat)(h: S m < S n),
@@ -404,23 +399,23 @@ Section Fin_def_tools.
   Proof.
     intros m n h.
     destruct n as [|n].
-    apply False_rec.
-    apply (le_Sn_O _ (gt_S_le _ _ h)).
-    simpl.
-    unfold sumor_rec ; unfold sumor_rect.
-    elim (lt_eq_lt_dec m (S n)); intros a.
-    destruct a as [H|H]; simpl.
-    f_equal.
-    elim (lt_eq_lt_dec m n); intros a.
-    destruct a as [H0|H0]; simpl;
-    reflexivity.
-    apply False_rec.
-    apply (lt_irrefl _ (le_lt_trans _ _ _ (lt_le_S _ _ a) H)).
-    apply False_rec.
-    rewrite H in h.
-    apply (lt_irrefl _ h).
-    apply False_rec.
-    apply (lt_irrefl _ (lt_trans _ _ _ (lt_n_S _ _ a) h)).
+    - apply False_rec.
+      apply (le_Sn_O _ (gt_S_le _ _ h)).
+    - simpl.
+      unfold sumor_rec ; unfold sumor_rect.
+      elim (lt_eq_lt_dec m (S n)); intros a.
+      + destruct a as [H|H]; simpl.
+        f_equal.
+        elim (lt_eq_lt_dec m n); intros a.
+        * destruct a as [H0|H0]; simpl;
+            reflexivity.
+        * apply False_rec.
+          apply (lt_irrefl _ (le_lt_trans _ _ _ (lt_le_S _ _ a) H)).
+        * apply False_rec.
+          rewrite H in h.
+          apply (lt_irrefl _ h).
+      + apply False_rec.
+        apply (lt_irrefl _ (lt_trans _ _ _ (lt_n_S _ _ a) h)).
   Qed.
 
   Lemma code_Fin3_aux_proofirr: forall (n m:nat)(h1 h2:m < S n),
@@ -428,59 +423,57 @@ Section Fin_def_tools.
   Proof.
     intros n m h1 h2.
     elim (lt_eq_lt_dec m n); intros a.
-    destruct a as [H|e].
-    destruct n as [|n].
-    inversion H.
-    simpl.
-    destruct m as [|m].
-    reflexivity.
-    elim (lt_eq_lt_dec m n); intros a.
-    destruct a as [H0|H0].
-    elim (lt_eq_lt_dec (S m) (S n)); intros a.
-    reflexivity.
-    apply False_rec.
-    apply (lt_irrefl _ (lt_trans _ _ _ a H)).
-    elim (lt_eq_lt_dec (S m) (S n)); intros a.
-    reflexivity.
-    apply False_rec.
-    apply (lt_irrefl _ (lt_trans _ _ _ a H)).
-    elim (lt_eq_lt_dec (S m) (S n)); intros b.
-    reflexivity.
-    apply False_rec.
-    apply (lt_irrefl _ (lt_trans _ _ _ b H)).
-
-    destruct n as [|n]; destruct m as [|m].
-    reflexivity.
-    inversion e.
-    inversion e.
-    simpl.
-    elim (lt_eq_lt_dec m n); intros a.
-    destruct a as [H|H].
-    apply False_rec.
-    apply lt_n_S in H.
-    rewrite e in H.
-    apply (lt_irrefl _ H).
-    reflexivity.
-    apply False_rec.
-    apply lt_n_S in a.
-    rewrite e in a.
-    apply (lt_irrefl _ a).
-
-    destruct n as [|n]; destruct m as [|m].
-    apply False_rec.
-    apply (lt_irrefl _ a).
-    apply False_rec.
-    apply (le_Sn_O _ (gt_S_le _ _ h2)).
-    inversion a.
-    simpl.
-    elim (lt_eq_lt_dec m n); intros b.
-    destruct b as [H|H] ; reflexivity.
-    apply False_rec.
-    inversion a as [e | x H e].
-    rewrite e in h2.
-    apply (lt_irrefl _ h2).
-    apply (lt_irrefl _ (lt_trans _ _ _ (lt_n_Sn _) 
-                                       (lt_le_trans _ _ _ h2 H))).
+    - destruct a as [H|e].
+      + destruct n as [|n].
+        * inversion H.
+        * cbn.
+          destruct m as [|m].
+          -- reflexivity.
+          -- elim (lt_eq_lt_dec m n); intros a.
+             ++ destruct a as [H0|H0].
+                ** elim (lt_eq_lt_dec (S m) (S n)); intros a.
+                   { reflexivity. }
+                   apply False_rec.
+                   apply (lt_irrefl _ (lt_trans _ _ _ a H)).
+                ** elim (lt_eq_lt_dec (S m) (S n)); intros a.
+                   { reflexivity. }
+                   apply False_rec.
+                   apply (lt_irrefl _ (lt_trans _ _ _ a H)).
+                   ++ elim (lt_eq_lt_dec (S m) (S n)); intros b.
+                      { reflexivity. }
+                      apply False_rec.
+                      apply (lt_irrefl _ (lt_trans _ _ _ b H)).
+      + destruct n as [|n]; destruct m as [|m].
+        * reflexivity.
+        * inversion e.
+        * inversion e.
+        * simpl.
+          elim (lt_eq_lt_dec m n); intros a.
+          -- destruct a as [H|H].
+             ++ apply False_rec.
+                apply lt_n_S in H.
+                rewrite e in H.
+                apply (lt_irrefl _ H).
+             ++ reflexivity.
+          -- apply False_rec.
+             apply lt_n_S in a.
+             rewrite e in a.
+             apply (lt_irrefl _ a).
+    - destruct n as [|n]; destruct m as [|m].
+      + apply False_rec.
+        apply (lt_irrefl _ a).
+      + apply False_rec.
+        apply (le_Sn_O _ (gt_S_le _ _ h2)).
+      + inversion a.
+      + simpl.
+        elim (lt_eq_lt_dec m n); intros b.
+        * destruct b as [H|H] ; reflexivity.
+        * apply False_rec.
+          inversion a as [e | x H e].
+          -- rewrite e in h2.
+             apply (lt_irrefl _ h2).
+          -- apply (lt_irrefl _ (lt_trans _ _ _ (lt_n_Sn _) 
+                                          (lt_le_trans _ _ _ h2 H))).
   Qed.
 
   (* Proof of the lemmas on code_Fin3 in order to prove the 
@@ -490,14 +483,14 @@ Section Fin_def_tools.
     intros n h.
     unfold code_Fin3; simpl.
     destruct n as [|n].
-    reflexivity.
+    { reflexivity. }
     elim (lt_eq_lt_dec (S n - 0) (S n)); intros a.
-    destruct a as [H|H].
-    apply False_rec.
-    apply (lt_irrefl _ H).
-    reflexivity.
-    apply False_rec.
-    apply (lt_irrefl _ a).
+    - destruct a as [H|H].
+      + apply False_rec.
+        apply (lt_irrefl _ H).
+      + reflexivity.
+    - apply False_rec.
+      apply (lt_irrefl _ a).
   Qed.
 
   Lemma code_Fin3_S: forall (n m:nat)(h:S m<S n),
@@ -506,36 +499,36 @@ Section Fin_def_tools.
     intros n m h.
     unfold code_Fin3.
     destruct n as [|n].
-    apply False_rec.
-    apply (le_Sn_O _ (gt_S_le _ _ h)).
-    elim (lt_eq_lt_dec (S n - S m) (S n)); intros a.
-    destruct a as [H|H].
-    simpl.
-    unfold sumor_rec; unfold sumor_rect.
-    elim (lt_eq_lt_dec (n - m) (S n)); intros a.
-    destruct a as [H0|H0].
-    elim (lt_eq_lt_dec (n - m) n); intros a;
-    [reflexivity | apply False_rec].
-    inversion H0 as [H2 | x H2 H3].
-    rewrite H2 in a.
-    apply (lt_irrefl _ a).
-    apply lt_n_S in a.
-    apply le_lt_n_Sm in H2.
-    apply (lt_irrefl _ (lt_trans _ _ _ a H2)).
-    apply False_rec.
-    rewrite <- Sn_Sm_eq_n_m in H0.
-    rewrite H0 in H.
-    apply (lt_irrefl _ H).
-    apply False_rec.
-    rewrite <- Sn_Sm_eq_n_m in a.
-    apply (lt_irrefl _ (lt_trans _ _ _ a H)).
-    apply False_rec.
-    apply (lt_n_Sm_le (S m) (S n)) in h.
-    apply (minus_reg_l h) in H.
-    inversion H.
-    apply False_rec.
-    apply (lt_irrefl _ (lt_trans _ _ _ a 
-      (lt_minus _ _ (lt_n_Sm_le (S m) (S n) h) (lt_O_Sn m)))).
+    - apply False_rec.
+      apply (le_Sn_O _ (gt_S_le _ _ h)).
+    - elim (lt_eq_lt_dec (S n - S m) (S n)); intros a.
+      + destruct a as [H|H].
+        * simpl.
+          unfold sumor_rec; unfold sumor_rect.
+          elim (lt_eq_lt_dec (n - m) (S n)); intros a.
+          -- destruct a as [H0|H0].
+             ++ elim (lt_eq_lt_dec (n - m) n); intros a;
+                  [reflexivity | apply False_rec].
+                inversion H0 as [H2 | x H2 H3].
+                ** rewrite H2 in a.
+                   apply (lt_irrefl _ a).
+                ** apply lt_n_S in a.
+                   apply le_lt_n_Sm in H2.
+                   apply (lt_irrefl _ (lt_trans _ _ _ a H2)).
+             ++ apply False_rec.
+                rewrite <- Sn_Sm_eq_n_m in H0.
+                rewrite H0 in H.
+                apply (lt_irrefl _ H).
+          -- apply False_rec.
+             rewrite <- Sn_Sm_eq_n_m in a.
+             apply (lt_irrefl _ (lt_trans _ _ _ a H)).
+        * apply False_rec.
+          apply (lt_n_Sm_le (S m) (S n)) in h.
+          apply (minus_reg_l h) in H.
+          inversion H.
+      + apply False_rec.
+        apply (lt_irrefl _ (lt_trans _ _ _ a 
+                   (lt_minus _ _ (lt_n_Sm_le (S m) (S n) h) (lt_O_Sn m)))).
   Qed.    
 
   Lemma code1_code3_eq: 
@@ -553,13 +546,13 @@ Section Fin_def_tools.
     rewrite <- (code1_decode_Id f1);
     rewrite <- (code1_decode_Id f2).
     destruct n as [|n].
-    inversion f1.
-    assert (h1 := decode_Fin_inf_n f1).
-    rewrite (code_Fin1_proofirr _ h1).
-    revert h1.
-    rewrite h.
-    intros h1.
-    apply code_Fin1_proofirr.
+    - inversion f1.
+    - assert (h1 := decode_Fin_inf_n f1).
+      rewrite (code_Fin1_proofirr _ h1).
+      revert h1.
+      rewrite h.
+      intros h1.
+      apply code_Fin1_proofirr.
   Qed.
 
   Lemma decode_Fin_0_first: 
@@ -574,31 +567,31 @@ Section Fin_def_tools.
   Definition mkFinn : forall (n: nat), Fin (S n).
   Proof.
     intros n ; induction n as [|n IH].
-    exact (first 0).
-    exact (succ IH).
+    - exact (first 0).
+    - exact (succ IH).
   Defined.
 
   Lemma decode_Fin_mkFinn_n : forall n, decode_Fin (mkFinn n) = n.
   Proof.
     induction n as [|n IH].
-    reflexivity.
-    simpl.
-    rewrite IH ; reflexivity.
+    - reflexivity.
+    - simpl.
+      rewrite IH ; reflexivity.
   Qed.
 
   Definition get_cons: forall (n: nat) (f: Fin (S n))(h: decode_Fin f > 0), Fin n.
   Proof.
     intros n f h.
     elim (O_or_S (decode_Fin f)); intro a.
-    destruct a as [x e].
-    assert (H: x < n).
-    apply lt_S_n.
-    rewrite e.
-    apply (decode_Fin_inf_n f).
-    exact (code_Fin1 H).
-    rewrite a in h.
-    apply False_rec.
-    apply (lt_irrefl _ h).
+    - destruct a as [x e].
+      assert (H: x < n).
+      { apply lt_S_n.
+        rewrite e.
+        apply (decode_Fin_inf_n f). }
+      exact (code_Fin1 H).
+    - rewrite a in h.
+      apply False_rec.
+      apply (lt_irrefl _ h).
   Defined.
 
   Lemma get_cons_ok: forall (n: nat)(f: Fin n), 
@@ -606,11 +599,11 @@ Section Fin_def_tools.
   Proof.
     intros n f.
     destruct n as [|n].
-    inversion f.
-    rewrite <- code1_decode_Id.
-    unfold get_cons.
-    simpl.
-    apply code_Fin1_proofirr.
+    - inversion f.
+    - rewrite <- code1_decode_Id.
+      unfold get_cons.
+      cbn.
+      apply code_Fin1_proofirr.
   Qed.
 
   Lemma get_cons_proofirr: forall (n: nat) (f: Fin (S n))(h h': decode_Fin f > 0), 
@@ -620,7 +613,7 @@ Section Fin_def_tools.
     apply decode_Fin_unique.
     unfold get_cons, sumor_rec, sumor_rect.
     elim (O_or_S (decode_Fin f)) ; intros b.
-    reflexivity.
+    { reflexivity. }
     apply False_rec.
     rewrite <- b in h.
     inversion h.
@@ -632,10 +625,10 @@ Section Fin_def_tools.
     rewrite <- (code1_decode_Id f).
     assert (h:= decode_Fin_inf_n f) ; rewrite (code_Fin1_proofirr _ h).
     elim (zerop (decode_Fin f)); intros a.
-    revert h ; rewrite a; intro h.
-    apply code_Fin1_0_.
-    apply False_rec. 
-    apply (lt_irrefl _ (lt_le_trans _ _ _ a (lt_n_Sm_le _ _ h))).
+    - revert h ; rewrite a; intro h.
+      apply code_Fin1_0_.
+    - apply False_rec. 
+      apply (lt_irrefl _ (lt_le_trans _ _ _ a (lt_n_Sm_le _ _ h))).
   Qed.
 
   Lemma decode_Fin_get_cons: forall (n: nat)(f: Fin (S n))(h: decode_Fin f > 0), 
@@ -643,15 +636,15 @@ Section Fin_def_tools.
   Proof.
     intros n f h.
     unfold get_cons.
-    simpl.
+    cbn.
     unfold sumor_rec ; unfold sumor_rect.
     elim (O_or_S (decode_Fin f)) ; [intros [m h1] | intros a].
-    rewrite decode_code1_Id.
-    rewrite h1.
-    reflexivity.
-    apply False_rec.
-    rewrite a in h.
-    apply (lt_irrefl _ h).
+    - rewrite decode_code1_Id.
+      rewrite h1.
+      reflexivity.
+    - apply False_rec.
+      rewrite a in h.
+      apply (lt_irrefl _ h).
   Qed.
 
   Lemma get_cons_ok1 (n: nat)(i: Fin (S n))(h: 0 < decode_Fin i) : 
@@ -672,8 +665,8 @@ Section Fin_def_tools.
     Proof.
       intros n.
       induction n as [|n IHn].
-      exact nil.
-      exact (cons (first n) (map (succ (k:= n)) IHn )).
+      - exact nil.
+      - exact (cons (first n) (map (succ (k:= n)) IHn )).
     Defined.
 
     Fixpoint makeListFin' (n: nat): list (Fin n):= 
@@ -692,22 +685,22 @@ Section Fin_def_tools.
     Proof.
       intros n.
       induction n as [|n IHn].
-      reflexivity.
-      rewrite <- IHn at 3.
-      simpl.
-      rewrite map_length.
-      reflexivity.
+      - reflexivity.
+      - rewrite <- IHn at 3.
+        cbn.
+        rewrite map_length.
+        reflexivity.
     Qed.
     
     Lemma all_Fin_n_in_makeListFin : forall (n: nat),
       forall f: Fin n, In f (makeListFin n).
     Proof.
       intros n f.
-      induction f as [k | k f IHf] ; simpl.
-      left; reflexivity.
-      right.
-      apply in_map.
-      apply IHf.
+      induction f as [k | k f IHf] ; cbn.
+      - left; reflexivity.
+      - right.
+        apply in_map.
+        apply IHf.
     Qed.
 	
     Lemma nth_makeListFin: forall (n m: nat)(h: m < n),
@@ -715,19 +708,19 @@ Section Fin_def_tools.
     Proof.
       induction n as [|n IHn]; 
       intros m h.
-      inversion h.
-      destruct m as [|m].
-      apply code_Fin1_Sn_0.
-      simpl.
-      destruct n as [|n].
-      apply False_rec.
-      apply (le_Sn_O _ (gt_S_le _ _ h)).
-      rewrite code_Fin1_Sn_S.
-      rewrite map_nth.
-      f_equal.
-      unfold code_Fin1 in IHn.
-      rewrite (code_Fin1_Sn_proofirr _ (lt_n_Sm_le m n (lt_S_n _ _ h))).
-      apply IHn.
+      - inversion h.
+      - destruct m as [|m].
+        + apply code_Fin1_Sn_0.
+        + cbn.
+          destruct n as [|n].
+          * apply False_rec.
+            apply (le_Sn_O _ (gt_S_le _ _ h)).
+          * rewrite code_Fin1_Sn_S.
+            rewrite map_nth.
+            f_equal.
+            unfold code_Fin1 in IHn.
+            rewrite (code_Fin1_Sn_proofirr _ (lt_n_Sm_le m n (lt_S_n _ _ h))).
+            apply IHn.
     Qed.
 
     Lemma nth_makeListFin_def: forall (n m: nat)(h: m < n)(d: Fin n),
@@ -735,9 +728,9 @@ Section Fin_def_tools.
     Proof.
       intros n m h f.
       rewrite (nth_indep (makeListFin n) f (code_Fin1 h)).
-      apply nth_makeListFin.
-      rewrite makeListFin_nb_elem_ok.
-      assumption.
+      - apply nth_makeListFin.
+      - rewrite makeListFin_nb_elem_ok.
+        assumption.
     Qed.
 
     Lemma makeListFin_S: forall n: nat, 
@@ -848,8 +841,8 @@ Section Fin_injectivity.
   Proof.
     intros i.
     elim (zerop (decode_Fin (f (succ i)))) ; intros a.
-    exact (get_cons _ (first_succ_neq H i a)).
-    exact (get_cons _ a).
+    - exact (get_cons _ (first_succ_neq H i a)).
+    - exact (get_cons _ a).
   Defined.
 
   Lemma FSnFSn'_FnFn'_ok1 (n n' : nat)(f: Fin (S n) -> Fin (S n'))
@@ -859,8 +852,8 @@ Section Fin_injectivity.
   Proof.
      unfold FSnFSn'_FnFn', sumbool_rec, sumbool_rect.
      elim (zerop (decode_Fin (f (succ i)))) ; intros a.
-     apply get_cons_proofirr.
-     apply False_rec, (lt_0_neq _ a), sym_eq, H1.
+     - apply get_cons_proofirr.
+     - apply False_rec, (lt_0_neq _ a), sym_eq, H1.
   Qed.
 
   Lemma FSnFSn'_FnFn'_ok2 (n n' : nat)(f: Fin (S n) -> Fin (S n'))
@@ -869,8 +862,8 @@ Section Fin_injectivity.
   Proof.
      unfold FSnFSn'_FnFn', sumbool_rec, sumbool_rect.
      elim (zerop (decode_Fin (f (succ i)))) ; intros a.
-     apply False_rec, (lt_0_neq _ H1), sym_eq, a.
-     apply get_cons_proofirr.
+     - apply False_rec, (lt_0_neq _ H1), sym_eq, a.
+     - apply get_cons_proofirr.
   Qed.
 
   Lemma FSnFSn'_FnFn'_proofirr (n n' : nat)(f: Fin (S n) -> Fin (S n'))
@@ -879,10 +872,10 @@ Section Fin_injectivity.
   Proof.
     intros i.
     elim (zerop (decode_Fin (f (succ i)))) ; intros a.
-    rewrite (FSnFSn'_FnFn'_ok1 H1 _ a), (FSnFSn'_FnFn'_ok1 H2 _ a).
-    apply get_cons_proofirr.
-    rewrite (FSnFSn'_FnFn'_ok2 H1 _ a), (FSnFSn'_FnFn'_ok2 H2 _ a).
-    apply get_cons_proofirr.
+    - rewrite (FSnFSn'_FnFn'_ok1 H1 _ a), (FSnFSn'_FnFn'_ok1 H2 _ a).
+      apply get_cons_proofirr.
+    - rewrite (FSnFSn'_FnFn'_ok2 H1 _ a), (FSnFSn'_FnFn'_ok2 H2 _ a).
+      apply get_cons_proofirr.
   Qed.
 
   Lemma succ_inj (n: nat)(i1 i2 : Fin n) : succ i1 = succ i2 -> i1 = i2.
@@ -900,24 +893,23 @@ Section Fin_injectivity.
   Proof.
     intros i ; destruct H1 as [H1 H3].
     elim (zerop (decode_Fin (f (succ i)))) ; intros a.
-    rewrite (FSnFSn'_FnFn'_ok1 _ _ a).
-    assert (b : decode_Fin (g (succ (get_cons (f (first n)) 
-      (first_succ_neq (conj H1 H3) i a)))) = 0).
-    rewrite get_cons_ok1, H1.
-    reflexivity.
-    rewrite (FSnFSn'_FnFn'_ok1 _ _ b).
-    apply succ_inj.
-    rewrite get_cons_ok1, <- (H1 (succ i)).
-    f_equal.
-    apply decode_Fin_unique, sym_eq, a.
-
-    rewrite (FSnFSn'_FnFn'_ok2 _ _ a).
-    assert (b : decode_Fin (g (succ (get_cons (f (succ i)) a))) > 0).
-    rewrite (get_cons_ok1 _ a), H1.
-    apply lt_0_Sn.
-    rewrite (FSnFSn'_FnFn'_ok2 _ _ b).
-    revert b ; rewrite (get_cons_ok1 _ a), H1 ; intros b.
-    apply get_cons_ok2.
+    - rewrite (FSnFSn'_FnFn'_ok1 _ _ a).
+      assert (b : decode_Fin (g (succ (get_cons (f (first n)) 
+                         (first_succ_neq (conj H1 H3) i a)))) = 0).
+      { rewrite get_cons_ok1, H1.
+        reflexivity. }
+      rewrite (FSnFSn'_FnFn'_ok1 _ _ b).
+      apply succ_inj.
+      rewrite get_cons_ok1, <- (H1 (succ i)).
+      f_equal.
+      apply decode_Fin_unique, sym_eq, a.
+    - rewrite (FSnFSn'_FnFn'_ok2 _ _ a).
+      assert (b : decode_Fin (g (succ (get_cons (f (succ i)) a))) > 0).
+      { rewrite (get_cons_ok1 _ a), H1.
+        apply lt_0_Sn. }
+      rewrite (FSnFSn'_FnFn'_ok2 _ _ b).
+      revert b ; rewrite (get_cons_ok1 _ a), H1 ; intros b.
+      apply get_cons_ok2.
   Qed.
 
   Lemma FSnFSn'_FnFn'_bij(n n' : nat)(f: Fin (S n) -> Fin (S n'))
@@ -933,15 +925,14 @@ Section Fin_injectivity.
   Bijective f g -> n = n'.
   Proof.
     induction n as [|n IH] ; intros [|n'] f g H.
-    reflexivity.
-    assert (i := g (first n')).
-    inversion i.
-    assert (i := f (first n)).
-    inversion i.
-  
-    f_equal.
-    apply (IH _ (FSnFSn'_FnFn' H) (FSnFSn'_FnFn' (Bij_sym H))).
-    apply FSnFSn'_FnFn'_bij.
+    - reflexivity.
+    - assert (i := g (first n')).
+      inversion i.
+    - assert (i := f (first n)).
+      inversion i.
+    - f_equal.
+      apply (IH _ (FSnFSn'_FnFn' H) (FSnFSn'_FnFn' (Bij_sym H))).
+      apply FSnFSn'_FnFn'_bij.
   Defined.
 
   Definition FnFn' (n n' : nat)(H : Fin n = Fin n')(i : Fin n) := 
@@ -957,7 +948,6 @@ Section Fin_injectivity.
   Lemma FnFn'_Fn'Fn_inv (n n' : nat)(H : Fin n = Fin n') : 
     forall i, FnFn' H (FnFn' (sym_eq H) i) = i.
   Proof.
-    
     unfold FnFn' ; rewrite H.
     reflexivity.
   Qed.
@@ -975,8 +965,8 @@ Section minus_Fin.
 Definition minusFin (n: nat)(i: Fin n): nat.
 Proof.
   induction i as [n|n i IH].
-  exact n.
-  exact IH.
+  - exact n.
+  - exact IH.
 Defined.
 
 Lemma minusFin1 (n: nat) : @minusFin (S n) (first n) = n.
@@ -992,16 +982,16 @@ Qed.
 Lemma minusFin3 (n: nat) : @minusFin (S n) (code_Fin1 (lt_n_Sn n)) = 0.
 Proof.
   induction n as [|n IH].
-  reflexivity.
-  assert (H1 : code_Fin1 (lt_n_Sn (S n)) = succ (code_Fin1 (lt_n_Sn n))).
-  apply decode_Fin_unique.
-  change (decode_Fin (code_Fin1 (lt_n_Sn (S n))) =
-  S (decode_Fin (code_Fin1 (lt_n_Sn n)))).
-  do 2 rewrite decode_code1_Id.
-  reflexivity.
-  rewrite H1.
-  rewrite  minusFin2.
-  assumption.
+  - reflexivity.
+  - assert (H1 : code_Fin1 (lt_n_Sn (S n)) = succ (code_Fin1 (lt_n_Sn n))).
+    { apply decode_Fin_unique.
+      change (decode_Fin (code_Fin1 (lt_n_Sn (S n))) =
+              S (decode_Fin (code_Fin1 (lt_n_Sn n)))).
+      do 2 rewrite decode_code1_Id.
+      reflexivity. }
+    rewrite H1.
+    rewrite  minusFin2.
+    assumption.
 Qed.
 
 End minus_Fin.

--- a/GPerm.v
+++ b/GPerm.v
@@ -55,10 +55,10 @@ Section GeqPerm.
     Proof.
       induction t as [lab l IH] using TreeG_ind_better.
       apply Teq_intro.
-      reflexivity.
-      apply (is_ilist_rel _ _ _ (refl_equal _)).
-      intro i.
-      apply IH.
+      - reflexivity.
+      - apply (is_ilist_rel _ _ _ (refl_equal _)).
+        intro i.
+        apply IH.
    Qed.
    
    Lemma Teq_sym (Rsym: Symmetric RelT) : forall t1 t2, Teq t1 t2 -> Teq t2 t1.
@@ -67,18 +67,18 @@ Section GeqPerm.
      intros [lab2 l2] H.
      inversion H as [t1 t2 H1 [h H2] H3 H4] ; clear t1 t2 H3 H4.
      apply Teq_intro.
-     symmetry.
-     assumption.
-     simpl in *|-*.
-     destruct l1 as [n l1] ; destruct l2 as [n2 l2].
-     simpl in *|-*.
-     revert l2 H H1 H2.
-     rewrite <- h.
-     intros l2 H H1 H2.
-     clear h n2.
-     apply (is_ilist_rel _ _ _ (refl_equal _ : lgti (existT _ n l2) = lgti (existT _ n l1))).
-     simpl in *|-*.
-     intro i ; apply (IH _ _ (H2 i)).
+     - symmetry.
+       assumption.
+     - cbn in *|-*.
+       destruct l1 as [n l1] ; destruct l2 as [n2 l2].
+       cbn in *|-*.
+       revert l2 H H1 H2.
+       rewrite <- h.
+       intros l2 H H1 H2.
+       clear h n2.
+       apply (is_ilist_rel _ _ _ (refl_equal _ : lgti (existT _ n l2) = lgti (existT _ n l1))).
+       cbn in *|-*.
+       intro i ; apply (IH _ _ (H2 i)).
    Qed.
 
    Lemma Teq_trans (Rtrans: Transitive RelT)  : forall t1 t2 t3, Teq t1 t2 -> Teq t2 t3 -> Teq t1 t3.
@@ -89,15 +89,15 @@ Section GeqPerm.
      inversion H2 as [t21 t22 H21 [h2 H22] H23 H24] ; 
      clear t11 t12 H13 H14 t21 t22 H23 H24 H1 H2.
      apply Teq_intro.
-     apply (transitivity H11 H21).
-     destruct l1 as [n l1] ; destruct l2 as [n2 l2] ; destruct l3 as [n3 l3].
-     simpl in *|-*.
-     revert h2 l2 l3 H11 H12 H21 H22.
-     rewrite <- h1.
-     intro h2 ; rewrite <- h2.
-     intros l2 l3 H11 H12 H21 H22.
-     apply (is_ilist_rel _ _ _ (refl_equal _ : lgti (existT _ n l1) = lgti (existT _ n l3))).
-     intro i ; apply (IH _ _ _ (H12 _) (H22 _)).
+     - apply (transitivity H11 H21).
+     - destruct l1 as [n l1] ; destruct l2 as [n2 l2] ; destruct l3 as [n3 l3].
+       cbn in *|-*.
+       revert h2 l2 l3 H11 H12 H21 H22.
+       rewrite <- h1.
+       intro h2 ; rewrite <- h2.
+       intros l2 l3 H11 H12 H21 H22.
+       apply (is_ilist_rel _ _ _ (refl_equal _ : lgti (existT _ n l1) = lgti (existT _ n l3))).
+       intro i ; apply (IH _ _ _ (H12 _) (H22 _)).
    Qed.
 
     Add Parametric Relation (Req: Equivalence RelT) : (TreeG) (Teq)
@@ -111,8 +111,8 @@ Section GeqPerm.
     Definition Graph2TreeG (n: nat)(g: Graph T) : TreeG.
     Proof.
       revert g ; induction n as [|n IH] ; intros [t l].
-      exact (mk_TreeG t (@inil _)).
-      exact (mk_TreeG t (imap IH l)).
+      - exact (mk_TreeG t (@inil _)).
+      - exact (mk_TreeG t (imap IH l)).
     Defined.
 
 (* the trivial corollaries *)
@@ -138,14 +138,14 @@ Section GeqPerm.
       ilist_rel eq (imap labelT (sonsT (Graph2TreeG n g))) (imap (@label _) (sons g)).
     Proof.
       destruct n as [|n]; destruct g as [lab l] ; intros h.
-      apply False_rec, (lt_irrefl _ h).
-      apply (is_ilist_rel _ _ _ (refl_equal _ : 
-        lgti (imap labelT (imap (fun x : Graph T => Graph2TreeG n x) l)) = lgti (imap (@label _) l))).
-      simpl.
-      intro i.
-      set (g := fcti l i).
-      destruct g as [lab' l'].
-      destruct n as [|n] ; reflexivity.
+      - apply False_rec, (lt_irrefl _ h).
+      - apply (is_ilist_rel _ _ _ (refl_equal _ : 
+          lgti (imap labelT (imap (fun x : Graph T => Graph2TreeG n x) l)) = lgti (imap (@label _) l))).
+        cbn.
+        intro i.
+        set (g := fcti l i).
+        destruct g as [lab' l'].
+        destruct n as [|n] ; reflexivity.
     Qed.
       
     (* Fundamental definition : permutation relation on TreeG *)
@@ -162,14 +162,14 @@ Section GeqPerm.
       match H in TeqPerm t' t0' return P t' t0' with
         TeqPerm_intro _ _ H1 H2 => _ end).
       apply Hyp.
-      assumption.
-      assumption.
-      induction H2.
-      apply IlistPerm3_nil; assumption.
-      apply (IlistPerm3_cons _ _ f1 f2).
-      apply IH.
-      assumption.
-      assumption.
+      - assumption.
+      - assumption.
+      - induction H2.
+        + apply IlistPerm3_nil; assumption.
+        + apply (IlistPerm3_cons _ _ f1 f2).
+          * apply IH.
+            assumption.
+          * assumption.
     Qed.
 
     (* In the following lines we show that TeqPerm preserves equivalence *)
@@ -177,15 +177,15 @@ Section GeqPerm.
     Proof.
       induction t as [lab [n l] IH] using TreeG_ind_better.
       apply TeqPerm_intro.
-      reflexivity.
+      { reflexivity. }
       revert l IH ; induction n as [|n IHn] ; intros l IH.
-      apply IlistPerm3_nil; reflexivity.
+      { apply IlistPerm3_nil; reflexivity. }
       apply (IlistPerm3_cons _ _ (first _ : Fin (lgti (mkilist l))) (first _ : Fin (lgti (mkilist l)))).
-      apply IH.
-      simpl in *|-*.
-      apply IHn.
-      intro i'.
-      apply (IH (succ i')).
+      - apply IH.
+      - cbn in *|-*.
+        apply IHn.
+        intro i'.
+        apply (IH (succ i')).
     Qed.
 
     Lemma TeqPerm_sym (Rsym: Symmetric RelT): forall t1 t2, TeqPerm t1 t2 -> TeqPerm t2 t1.
@@ -193,9 +193,9 @@ Section GeqPerm.
       intros t1 t2 Hyp.
       induction Hyp using TeqPerm_ind_better ; clear H0.
       apply TeqPerm_intro.
-      symmetry.
-      assumption.
-      apply IlistPerm3_flip', H1.
+      - symmetry.
+        assumption.
+      - apply IlistPerm3_flip', H1.
     Qed.
 
    Lemma TeqPerm_trans (Rtrans: Transitive RelT): 
@@ -206,11 +206,11 @@ Section GeqPerm.
       inversion_clear H1 as [t' t'' H11 H12].
       inversion_clear H2 as [t' t'' H21 H22].
       apply TeqPerm_intro.
-      apply (transitivity H11 H21).
-      apply IlistPerm3_IlistPerm4_eq in H12 ;  
-      apply IlistPerm3_IlistPerm4_eq in H22.
-      apply IlistPerm4_IlistPerm3_eq.
-      apply (IlistPerm4_trans_refined H H12 H22).
+      - apply (transitivity H11 H21).
+      - apply IlistPerm3_IlistPerm4_eq in H12 ;  
+          apply IlistPerm3_IlistPerm4_eq in H22.
+        apply IlistPerm4_IlistPerm3_eq.
+        apply (IlistPerm4_trans_refined H H12 H22).
    Qed.
 
     Add Parametric Relation (Req: Equivalence RelT) : (TreeG) (TeqPerm)
@@ -227,28 +227,25 @@ Section GeqPerm.
       cofix Hc.
       intros [lab1 sons1] [lab2 sons2] H.
       apply Geq_intro.
-      assert (H1 := H 0).
-      simpl in *|-*.
-      inversion H1 as [t1 t2 H2 H3 H4 H5] ; clear t1 t2 H3 H4 H5.
-      assumption.
-      
-      assert (H1 := H 1).
-      inversion H1 as [t1 t2 H2 [H3 H4] H5 H6] ; clear t1 t2 H2 H4 H5 H6.
-      
-      simpl lgti in *|-*.
-      apply (is_ilist_rel _ _ _ H3).
-      clear H1.
-      intro i.
-      apply Hc.
-      
-      intro n.
-      assert (H1 := H (S n)).
-      simpl in H1.
-      inversion H1 as [t1 t2 H4 [H5 H6] H7 H8] ; clear t1 t2 H4 H7 H8.
-      simpl in H5, H6.
-      assert (H7 : rewriteFins H5 i = rewriteFins H3 i).
-      treatFinPure.
-      rewrite <- H7 ; apply (H6 i).
+      - assert (H1 := H 0).
+        cbn in *|-*.
+        inversion H1 as [t1 t2 H2 H3 H4 H5] ; clear t1 t2 H3 H4 H5.
+        assumption.
+      - assert (H1 := H 1).
+        inversion H1 as [t1 t2 H2 [H3 H4] H5 H6] ; clear t1 t2 H2 H4 H5 H6.
+        simpl lgti in *|-*.
+        apply (is_ilist_rel _ _ _ H3).
+        clear H1.
+        intro i.
+        apply Hc.
+        intro n.
+        assert (H1 := H (S n)).
+        cbn in H1.
+        inversion H1 as [t1 t2 H4 [H5 H6] H7 H8] ; clear t1 t2 H4 H7 H8.
+        cbn in H5, H6.
+        assert (H7 : rewriteFins H5 i = rewriteFins H3 i).
+        { treatFinPure. }
+        rewrite <- H7 ; apply (H6 i).
     Qed.
 
     Lemma Geq_Teq(g1 g2 : Graph T) : Geq RelT g1 g2 -> 
@@ -259,24 +256,24 @@ Section GeqPerm.
       induction n as [|n IH] ; intros [lab1 sons1] [lab2 sons2] H ; 
       inversion H as [g1 g2 H1 [H2 H3] H4 H5] ; clear g1 g2 H4 H5;
       apply Teq_intro.
-      assumption.
-      simpl.
-      apply (is_ilist_rel _ _ _ (refl_equal _)).
-      intro i ; inversion i.
-      assumption.
-      simpl.
-      simpl in H2.
-      assert (H4 : lgti (imap (fun x : Graph T => Graph2TreeG n x) sons1) = 
-        lgti (imap (fun x : Graph T => Graph2TreeG n x) sons2)).
-      do 2 rewrite imap_lgti.
-      assumption.
-      apply (is_ilist_rel _ _ _ H4).
-      simpl.
-      intro i.
-      apply IH.
-      simpl in H3.
-      assert (H5 : rewriteFins H2 i = rewriteFins H4 i).
-      treatFinPure.
+      - assumption.
+      - cbn.
+        apply (is_ilist_rel _ _ _ (refl_equal _)).
+        intro i ; inversion i.
+      - assumption.
+      - cbn.
+        cbn in H2.
+        assert (H4 : lgti (imap (fun x : Graph T => Graph2TreeG n x) sons1) = 
+            lgti (imap (fun x : Graph T => Graph2TreeG n x) sons2)).
+        { do 2 rewrite imap_lgti.
+         assumption. }
+        apply (is_ilist_rel _ _ _ H4).
+        cbn.
+        intro i.
+        apply IH.
+        cbn in H3.
+        assert (H5 : rewriteFins H2 i = rewriteFins H4 i).
+      { treatFinPure. }
       assert (H6 := H3 i).
       rewrite H5 in H6.
       assumption.
@@ -332,9 +329,9 @@ Section GeqPerm.
       assert (H := Hyp1 _ _ Hyp2).
       destruct H as [H1 H2].
       split.
-      assumption.
-      apply (@IlistPerm3_mon _ _ _ R) ; try assumption.
-      exact (GeqPerm_coind Hyp1).
+      - assumption.
+      - apply (@IlistPerm3_mon _ _ _ R) ; try assumption.
+        exact (GeqPerm_coind Hyp1).
     Qed.
   
     Lemma GeqPerm_intro: forall g1 g2, RelT (label g1) (label g2) -> 
@@ -345,10 +342,10 @@ Section GeqPerm.
         /\ IlistPerm3 GeqPerm (sons g1) (sons g2))).
       clear g1 g2 H1 H2 ; intros g1 g2 [H1 H2].
       split ; try assumption.
-      apply (@IlistPerm3_mon _ _ _ GeqPerm) ; try assumption.
-      red.
-      apply GeqPerm_out.
-      split; assumption.
+      - apply (@IlistPerm3_mon _ _ _ GeqPerm) ; try assumption.
+        red.
+        apply GeqPerm_out.
+      - split; assumption.
     Qed.
       
     Lemma GeqPerm0_GeqPerm: subrelation GeqPerm0 GeqPerm.
@@ -415,15 +412,15 @@ Section GeqPerm.
       RelT (label g1) (label g2) <-> TeqPermn 0 g1 g2.
    Proof.
      split; intro Hyp.
-     red.
-     do 2 rewrite Graph2TreeG_ok0.
-     apply TeqPerm_intro.
-     assumption.
-     apply IlistPerm3nil.
-(* other direction *)
-     inversion_clear Hyp as [g3 g4 H1 _].
-     do 2 rewrite Graph2TreeG_ok0 in H1.
-     assumption.     
+     - red.
+       do 2 rewrite Graph2TreeG_ok0.
+       apply TeqPerm_intro.
+       + assumption.
+       + apply IlistPerm3nil.
+     - (* other direction *)
+       inversion_clear Hyp as [g3 g4 H1 _].
+       do 2 rewrite Graph2TreeG_ok0 in H1.
+       assumption.     
    Qed.
 
    Lemma TeqPermn_Sn (n:nat)(g1 g2: Graph T): 
@@ -434,9 +431,9 @@ Section GeqPerm.
      red.
      do 2 rewrite Graph2TreeG_okS.
      apply TeqPerm_intro.
-     assumption.
-     apply IlistPerm3_imap_bis.
-     assumption.
+     - assumption.
+     - apply IlistPerm3_imap_bis.
+       assumption.
    Qed.
 
    Lemma TeqPermn_Sn_back (n:nat)(g1 g2: Graph T): TeqPermn (S n) g1 g2 ->
@@ -445,11 +442,11 @@ Section GeqPerm.
      intro Hyp ; red in Hyp.
      do 2 rewrite Graph2TreeG_okS in Hyp.
      inversion_clear Hyp as [g3 g4 H1 H2].
-     simpl in *|-*.
+     cbn in *|-*.
      split.
-     assumption.
-     apply (IlistPerm3_imap_back(f1:=Graph2TreeG n)(f2:=Graph2TreeG n)).
-     assumption.
+     - assumption.
+     - apply (IlistPerm3_imap_back(f1:=Graph2TreeG n)(f2:=Graph2TreeG n)).
+       assumption.
    Qed.
 
 (* Note that the last three lemmas characterize TeqPermn for all n. In other
@@ -460,14 +457,12 @@ Section GeqPerm.
     Proof.
       revert g1 g2 ; induction n as [|n IHn] ; intros g1 g2 H1 ; 
       destruct (TeqPermn_Sn_back H1) as [H2 H3].
-      apply TeqPermn_0.
-      assumption.
-      apply TeqPermn_Sn.
-      assumption.
-      apply (IlistPerm3_mon IHn H3).
+      - apply TeqPermn_0.
+        assumption.
+      - apply TeqPermn_Sn.
+        + assumption.
+        + apply (IlistPerm3_mon IHn H3).
     Qed.
-
-
 
 
 (* Lemma TeqPerm_Graph2TreeG_n_Sn can be generalized to arbitrary differences: *)
@@ -475,9 +470,9 @@ Section GeqPerm.
      TeqPermn n g1 g2 -> TeqPermn m g1 g2.
    Proof. 
      induction Hyp as [| n H1 IH]; intro H2.
-     assumption.
-     apply IH.
-     apply TeqPermn_Sn_n, H2.
+     - assumption.
+     - apply IH.
+       apply TeqPermn_Sn_n, H2.
    Qed.
 
    Lemma TeqPermn_dec (Req: Equivalence RelT)(Rdec : forall t1 t2, {RelT t1 t2}+{not (RelT t1 t2)}): 
@@ -485,26 +480,24 @@ Section GeqPerm.
    Proof.
      intros g1 g2 n ; revert g1 g2 ; induction n as [|n IH] ; intros g1 g2 ;
      elim (Rdec (label g1) (label g2)); intros H1.
-     left.
-     apply TeqPermn_0.
-     assumption.
-     right.
-     intros H2.
-     contradiction H1.
-     apply TeqPermn_0, H2.
-
-     elim (IlistPerm3_dec _ IH (sons g1) (sons g2)) ; intros H2.
-     left.
-     apply TeqPermn_Sn; assumption.
-     right.
-     intros H3.
-     destruct (TeqPermn_Sn_back H3) as [_ H4].
-     contradiction H2.
-
-     right.
-     intros H2.
-     destruct (TeqPermn_Sn_back H2) as [H3 _].
-     contradiction H3.
+     - left.
+       apply TeqPermn_0.
+       assumption.
+     - right.
+       intros H2.
+       contradiction H1.
+       apply TeqPermn_0, H2.
+     - elim (IlistPerm3_dec _ IH (sons g1) (sons g2)) ; intros H2.
+       + left.
+         apply TeqPermn_Sn; assumption.
+       + right.
+         intros H3.
+         destruct (TeqPermn_Sn_back H3) as [_ H4].
+         contradiction H2.
+     - right.
+       intros H2.
+       destruct (TeqPermn_Sn_back H2) as [H3 _].
+       contradiction H3.
    Qed.
 
     (* The definition that should be equivalent to GeqPerm *)
@@ -543,10 +536,10 @@ Section GeqPerm.
       intros g1 g2 H n.
       revert g1 g2 H.
       induction n as [|n IH] ; intros _ _ [g1 g2 H1 H2].
-      apply TeqPermn_0, H1.
-      apply TeqPermn_Sn.
-      apply H1.
-      apply (IlistPerm3_mon IH), H2.
+      - apply TeqPermn_0, H1.
+      - apply TeqPermn_Sn.
+        + apply H1.
+        + apply (IlistPerm3_mon IH), H2.
     Qed.
 
 (* we even have the slightly stronger statement with GeqPerm in place of GeqPerm0 *)
@@ -555,24 +548,24 @@ Section GeqPerm.
       intros g1 g2 H n ; revert g1 g2 H.
       induction n as [|n IH] ; intros [lab1 sons1] [lab2 sons2] H;
       apply GeqPerm_out in H; destruct H as [H1 H2]; apply TeqPerm_intro ; try assumption.
-      simpl ; apply IlistPerm3nil.
-      do 2 rewrite Graph2TreeG_okS.
-      apply (IlistPerm3_mon IH) in H2.
-      apply IlistPerm3_imap_bis.
-      assumption.
+      - cbn ; apply IlistPerm3nil.
+      - do 2 rewrite Graph2TreeG_okS.
+        apply (IlistPerm3_mon IH) in H2.
+        apply IlistPerm3_imap_bis.
+        assumption.
     Qed.
 
     Lemma GeqPerm1_TeqPerm: subrelation GeqPerm1 TeqPerm_gene.
     Proof.
       intros g1 g2 H n ; revert g1 g2 H.
       induction n as [|n IH] ; intros [lab1 sons1] [lab2 sons2] H ;
-      inversion H as [g1' g2' X S H1 H2 H4 H5] ; clear g1' g2' H4 H5 ; apply TeqPerm_intro ; 
-      try assumption.
-      simpl ; apply IlistPerm3nil.
-      do 2 rewrite Graph2TreeG_okS.
-      apply (IlistPerm3_mon S), (IlistPerm3_mon IH) in H2.
-      apply IlistPerm3_imap_bis.
-      assumption.
+        inversion H as [g1' g2' X S H1 H2 H4 H5] ; clear g1' g2' H4 H5 ; apply TeqPerm_intro ; 
+        try assumption.
+      - cbn ; apply IlistPerm3nil.
+      - do 2 rewrite Graph2TreeG_okS.
+        apply (IlistPerm3_mon S), (IlistPerm3_mon IH) in H2.
+        apply IlistPerm3_imap_bis.
+        assumption.
     Qed.
 
 (* we describe a particular instance of the infinite pigeonhole principle *)
@@ -590,14 +583,15 @@ Lemma TeqPerm_gene_IlistPerm3: IPPIlistPerm3Cert ->  forall(g1 g2 : Graph T),
     Proof.
       intros IPP g1 g2 H.
       assert (Hyp: lgti (sons g1) = lgti (sons g2)).
-      destruct (TeqPermn_Sn_back (H 1)) as [_ H1].
-      apply (IlistPerm3_lgti H1).
+      { destruct (TeqPermn_Sn_back (H 1)) as [_ H1].
+        apply (IlistPerm3_lgti H1). }
       assert (H0: forall n:nat, exists f: IlistPerm3Cert_list(lgti (sons g1)), 
         IlistPerm3Cert (TeqPermn n) (sons g1) (sons g2) Hyp f).
-      intro n.
-      apply IlistPerm3_IlistPerm3Cert.
-      destruct (TeqPermn_Sn_back (H (S n))) as [_ Hn].
-      assumption.
+      { intro n.
+        apply IlistPerm3_IlistPerm3Cert.
+        destruct (TeqPermn_Sn_back (H (S n))) as [_ Hn].
+        assumption.
+      }
       destruct (IPP _ _ H0) as [f0 f0good].
       apply (IlistPerm3Cert_IlistPerm3 (Hyp:= Hyp)(f:= f0)).
       apply IlistPerm3Cert_inter.
@@ -614,8 +608,8 @@ Lemma TeqPerm_gene_IlistPerm3: IPPIlistPerm3Cert ->  forall(g1 g2 : Graph T),
       apply (GeqPerm_coind (R:=TeqPerm_gene)); try assumption.
       clear g1 g2 Hyp ; intros g1 g2 H.
       split.
-      apply TeqPermn_0, (H 0).
-      apply (TeqPerm_gene_IlistPerm3 IPP H).
+      - apply TeqPermn_0, (H 0).
+      - apply (TeqPerm_gene_IlistPerm3 IPP H).
     Qed.
 
     Lemma TeqPerm_GeqPerm1: IPPIlistPerm3Cert -> subrelation TeqPerm_gene GeqPerm1.
@@ -623,9 +617,9 @@ Lemma TeqPerm_gene_IlistPerm3: IPPIlistPerm3Cert ->  forall(g1 g2 : Graph T),
       intro IPP.
       cofix Hc ; intros g1 g2 H.
       apply (GeqPerm1_intro _ _ Hc).
-      set (H0 := H 0) ; inversion H0 as [g1' g2' H1 H2 H3 H4] ; clear g1' g2' H2 H3 H4.
-      do 2 rewrite Graph2TreeG_ok0 in H1 ; assumption.
-      apply (TeqPerm_gene_IlistPerm3 IPP H).
+      - set (H0 := H 0) ; inversion H0 as [g1' g2' H1 H2 H3 H4] ; clear g1' g2' H2 H3 H4.
+        do 2 rewrite Graph2TreeG_ok0 in H1 ; assumption.
+      - apply (TeqPerm_gene_IlistPerm3 IPP H).
     Qed.
 
     Lemma GeqPerm_refl_indirect (IPP: IPPIlistPerm3Cert)(Rrefl : Reflexive RelT): forall g, GeqPerm g g.
@@ -638,15 +632,15 @@ Lemma TeqPerm_gene_IlistPerm3: IPPIlistPerm3Cert ->  forall(g1 g2 : Graph T),
     Proof.
       intros g.
       apply (GeqPerm_coind (R:= @eq (Graph T))); try assumption ; split; rewrite H.
-      reflexivity.
-      apply IlistPerm3_refl, eq_equivalence.
+      - reflexivity.
+      - apply IlistPerm3_refl, eq_equivalence.
     Qed.
 
     Lemma GeqPerm1_refl(Rrefl : Reflexive RelT): forall g, GeqPerm1 g g.
     Proof.
       assert (Gen: forall g1 g2 : Graph T, g1 = g2 -> GeqPerm1 g1 g2).
-      cofix Hc ; intros g1 g2 Hyp ; apply (GeqPerm1_intro _ _ Hc) ; rewrite Hyp ; try reflexivity.
-      apply IlistPerm3_refl, eq_equivalence.
+      { cofix Hc ; intros g1 g2 Hyp ; apply (GeqPerm1_intro _ _ Hc) ; rewrite Hyp ; try reflexivity.
+        apply IlistPerm3_refl, eq_equivalence. }
       intro g ; apply Gen ; reflexivity.
     Qed.
 
@@ -659,21 +653,21 @@ Lemma TeqPerm_gene_IlistPerm3: IPPIlistPerm3Cert ->  forall(g1 g2 : Graph T),
     (* a direct proof that does not pass through TeqPerm_gene *)
     Lemma GeqPerm_sym (Rsym : Symmetric RelT) : forall g1 g2, GeqPerm g1 g2 -> GeqPerm g2 g1.
     Proof.
-      intros g1 g2 H ;apply (GeqPerm_coind (R:= fun g1 g2 => GeqPerm g2 g1)) ; try assumption.
+      intros g1 g2 H ; apply (GeqPerm_coind (R:= fun g1 g2 => GeqPerm g2 g1)) ; try assumption.
       clear g1 g2 H ; intros g1 g2 H ; destruct (GeqPerm_out H) as [H1 H2].
       split.
-      symmetry ; assumption.
-      apply (IlistPerm3_flip H2).
+      - symmetry ; assumption.
+      - apply (IlistPerm3_flip H2).
     Qed.
 
     Lemma GeqPerm1_sym (Rsym : Symmetric RelT) : forall g1 g2, GeqPerm1 g1 g2 -> GeqPerm1 g2 g1.
     Proof.
       cofix Hc ; intros g1 g2 H.
       apply (GeqPerm1_intro _ _ (X:= fun g1 g2 => GeqPerm1 g2 g1)) ; destruct H as [g1 g2 X S H1 H2].
-      clear g1 g2 X S H1 H2 ; intros g1 g2 H.
-      apply (Hc _ _ H).
-      apply (Rsym _ _ H1).
-      apply (IlistPerm3_flip (IlistPerm3_mon S H2)).
+      - clear g1 g2 X S H1 H2 ; intros g1 g2 H.
+        apply (Hc _ _ H).
+      - apply (Rsym _ _ H1).
+      - apply (IlistPerm3_flip (IlistPerm3_mon S H2)).
     Qed.
 
     Lemma GeqPerm_trans_indirect (IPP: IPPIlistPerm3Cert)(Rtrans: Transitive RelT): 
@@ -688,12 +682,12 @@ Lemma TeqPerm_gene_IlistPerm3: IPPIlistPerm3Cert ->  forall(g1 g2 : Graph T),
     Proof.
       intros g1 g2 g3 H1 H2.
       apply (GeqPerm_coind (R:= fun g1 g3 => exists g2, GeqPerm g1 g2 /\ GeqPerm g2 g3)).
-      clear g1 g2 g3 H1 H2 ; intros g1 g3 [g2 [Hyp1 Hyp2]].
-      destruct (GeqPerm_out Hyp1) as [Hyp11 Hyp12] ; destruct (GeqPerm_out Hyp2) as [Hyp21 Hyp22].
-      split.
-      transitivity (label g2); assumption.
-      apply (IlistPerm3_trans_special Hyp12 Hyp22).
-      exists g2 ; split; assumption.
+      - clear g1 g2 g3 H1 H2 ; intros g1 g3 [g2 [Hyp1 Hyp2]].
+        destruct (GeqPerm_out Hyp1) as [Hyp11 Hyp12] ; destruct (GeqPerm_out Hyp2) as [Hyp21 Hyp22].
+        split.
+        + transitivity (label g2); assumption.
+        + apply (IlistPerm3_trans_special Hyp12 Hyp22).
+      - exists g2 ; split; assumption.
     Qed.
 
     Lemma GeqPerm1_trans (Rtrans: Transitive RelT) : 
@@ -702,10 +696,10 @@ Lemma TeqPerm_gene_IlistPerm3: IPPIlistPerm3Cert ->  forall(g1 g2 : Graph T),
       cofix Hc ; intros g1 g2 g3 H1 H2.
       apply (GeqPerm1_intro _ _  (X:= fun g1 g3 => exists g2, GeqPerm1 g1 g2 /\ GeqPerm1 g2 g3)) ; 
       destruct H1 as [g1' g2' X1 S1 H1' H1] ;destruct H2 as [g2'' g3' X2 S2 H2' H2].
-      clear g1' X1 S1 H1' g2'' g3' X2 S2 H2' H1 H2 ; intros g1 g3 [g2 [H1 H2]] ; exact (Hc _ _ _ H1 H2).
-      transitivity (label g2''); assumption.
-      apply (IlistPerm3_trans_special (i2:= sons g2'')) ;
-      [apply (IlistPerm3_mon S1 H1) | apply (IlistPerm3_mon S2 H2)].
+      - clear g1' X1 S1 H1' g2'' g3' X2 S2 H2' H1 H2 ; intros g1 g3 [g2 [H1 H2]] ; exact (Hc _ _ _ H1 H2).
+      - transitivity (label g2''); assumption.
+      - apply (IlistPerm3_trans_special (i2:= sons g2'')) ;
+          [apply (IlistPerm3_mon S1 H1) | apply (IlistPerm3_mon S2 H2)].
     Qed.
 
     (* Recording that GeqPerm preserves equivalence *)
@@ -726,12 +720,11 @@ End GeqPerm.
     Proof.
       intros g1 g2 H1 i.
       induction H1 as [g2 H1 | g2 i' H1 IH].
-      destruct (GeqPerm_out H1) as [H2 H3].
-      destruct (IlistPerm3_exists_rec H3 i) as [i' [H4 _]].
-      apply (is_Graph_in_Graph_Gene_indir _ i').
-      apply (is_Graph_in_Graph_Gene_dir _ _ _ H4).
-      
-      apply (is_Graph_in_Graph_Gene_indir _ i' IH).
+      - destruct (GeqPerm_out H1) as [H2 H3].
+        destruct (IlistPerm3_exists_rec H3 i) as [i' [H4 _]].
+        apply (is_Graph_in_Graph_Gene_indir _ i').
+        apply (is_Graph_in_Graph_Gene_dir _ _ _ H4).
+      - apply (is_Graph_in_Graph_Gene_indir _ i' IH).
     Qed.
 
     Lemma Graph_in_Graph_Perm_trans (T: Set)(RelT: relation T)(Rtrans: Transitive RelT): 
@@ -741,13 +734,11 @@ End GeqPerm.
       intros g1 g2 g3 H1 H2.
       revert H2.
       induction H1 as [g2 H1 | g2 i H1 IH1] ; intros H2.
-      induction H2 as [g3 H2 | g3 i' H2 IH2].
-
-      apply (is_Graph_in_Graph_Gene_dir ).
-      apply (GeqPerm_trans _ H1 H2).
-      apply (is_Graph_in_Graph_Gene_indir _ i' IH2).
-
-      apply IH1, GinGP_sons, H2.
+      - induction H2 as [g3 H2 | g3 i' H2 IH2].
+        + apply (is_Graph_in_Graph_Gene_dir ).
+          apply (GeqPerm_trans _ H1 H2).
+        + apply (is_Graph_in_Graph_Gene_indir _ i' IH2).
+      - apply IH1, GinGP_sons, H2.
     Qed.
 
     Add Parametric Morphism (T: Set)(RelT: relation T)(Rtrans: Transitive RelT)(g: Graph T) : 
@@ -757,16 +748,16 @@ End GeqPerm.
       intros g1 g2 Heq H.
       revert g2 Heq.
       induction H as [g1 H1 | g1 i H1 IH]; intros g2 H2.
-      apply is_Graph_in_Graph_Gene_dir.
-      apply (GeqPerm_trans _ H1 H2).
-      apply GeqPerm_out in H2.
-      destruct H2 as [H2 H3].
-      apply IlistPerm3_IlistPerm4_eq in H3.
-      inversion H3 as [l1 l2 H4 H5 H6 H7] ; clear l1 l2 H6 H7.
-      destruct (H5 i) as [i2 [H6 H7]].
-      apply (is_Graph_in_Graph_Gene_indir _ i2).
-      apply IH.
-      assumption.
+      - apply is_Graph_in_Graph_Gene_dir.
+        apply (GeqPerm_trans _ H1 H2).
+      - apply GeqPerm_out in H2.
+        destruct H2 as [H2 H3].
+        apply IlistPerm3_IlistPerm4_eq in H3.
+        inversion H3 as [l1 l2 H4 H5 H6 H7] ; clear l1 l2 H6 H7.
+        destruct (H5 i) as [i2 [H6 H7]].
+        apply (is_Graph_in_Graph_Gene_indir _ i2).
+        apply IH.
+        assumption.
     Qed.
 
     Add Parametric Morphism (T: Set)(RelT: relation T)(Req: Equivalence RelT)(g: Graph T) : 
@@ -776,8 +767,8 @@ End GeqPerm.
       intros g1 g2 Heq H.
       revert g2 Heq.
       induction H as [g H1 | g i H1 IH]; intros g2 H2.
-      apply (is_Graph_in_Graph_Gene_dir _ _ _ (GeqPerm_trans _ (GeqPerm_sym _ H2) H1)).
-      apply (is_Graph_in_Graph_Gene_indir g i (IH _ H2)).
+      - apply (is_Graph_in_Graph_Gene_dir _ _ _ (GeqPerm_trans _ (GeqPerm_sym _ H2) H1)).
+      - apply (is_Graph_in_Graph_Gene_indir g i (IH _ H2)).
     Qed.
 
 End GinGP.
@@ -804,8 +795,8 @@ Section GPPerm.
   Proof.
     intros g1 g2 g3 [h1 h1'] [h2 h2'].
     apply GPPerm_intro.
-    apply (Graph_in_Graph_Perm_trans _ h1 h2).
-    apply (Graph_in_Graph_Perm_trans _ h2' h1').
+    - apply (Graph_in_Graph_Perm_trans _ h1 h2).
+    - apply (Graph_in_Graph_Perm_trans _ h2' h1').
   Qed.
 
   Add Parametric Relation(T: Set)(RelT : relation T)(Req: Equivalence RelT): (Graph T) (GPPerm RelT)
@@ -824,37 +815,36 @@ CoFixpoint G10 : Graph nat := let g0 := mk_Graph 0 (singleton G10) in mk_Graph 1
 Lemma GPPerm_G01_G10 : GPPerm eq G01 G10.
 Proof.
   apply GPPerm_intro.
-  apply (is_Graph_in_Graph_Gene_indir _ (first _: Fin (lgti (sons G10)))).
-  apply is_Graph_in_Graph_Gene_dir.
-  apply GeqPerm0_GeqPerm.
-  cofix Hc.
-  apply GeqPerm0_intro.
-  reflexivity.
-  apply (IlistPerm3_cons _ _ (first _: Fin (lgti (singleton (mk_Graph 1 (singleton G01))))) 
-    (first _ : Fin (lgti (singleton G10)))).
-  apply GeqPerm0_intro.
-  reflexivity.
-  apply (IlistPerm3_cons _ _ (first _: Fin (lgti (singleton G01))) 
-    (first _ : Fin (lgti (singleton (mk_Graph 0 (singleton G10)))))).
-  assumption.
-  simpl ; apply IlistPerm3nil.
-  simpl ; apply IlistPerm3nil.
-
-  apply (is_Graph_in_Graph_Gene_indir _ (first _: Fin (lgti (sons G01)))).
-  apply is_Graph_in_Graph_Gene_dir.
-  apply GeqPerm0_GeqPerm.
-  cofix Hc.
-  apply GeqPerm0_intro.
-  reflexivity.
-  apply (IlistPerm3_cons _ _ (first _: Fin (lgti (singleton (mk_Graph 0 (singleton G10))))) 
-    (first _ : Fin (lgti (singleton G01)))).
-  apply GeqPerm0_intro.
-  reflexivity.
-  apply (IlistPerm3_cons _ _ (first _: Fin (lgti (singleton G10))) 
-    (first _ : Fin (lgti (singleton (mk_Graph 1 (singleton G01)))))).
-  assumption.
-  simpl ; apply IlistPerm3nil.
-  simpl ; apply IlistPerm3nil.
+  - apply (is_Graph_in_Graph_Gene_indir _ (first _: Fin (lgti (sons G10)))).
+    apply is_Graph_in_Graph_Gene_dir.
+    apply GeqPerm0_GeqPerm.
+    cofix Hc.
+    apply GeqPerm0_intro.
+    + reflexivity.
+    + apply (IlistPerm3_cons _ _ (first _: Fin (lgti (singleton (mk_Graph 1 (singleton G01))))) 
+        (first _ : Fin (lgti (singleton G10)))).
+      * apply GeqPerm0_intro.
+        -- reflexivity.
+        -- apply (IlistPerm3_cons _ _ (first _: Fin (lgti (singleton G01))) 
+             (first _ : Fin (lgti (singleton (mk_Graph 0 (singleton G10)))))).
+           ++ assumption.
+           ++ cbn ; apply IlistPerm3nil.
+      * cbn ; apply IlistPerm3nil.
+  - apply (is_Graph_in_Graph_Gene_indir _ (first _: Fin (lgti (sons G01)))).
+    apply is_Graph_in_Graph_Gene_dir.
+    apply GeqPerm0_GeqPerm.
+    cofix Hc.
+    apply GeqPerm0_intro.
+    + reflexivity.
+    + apply (IlistPerm3_cons _ _ (first _: Fin (lgti (singleton (mk_Graph 0 (singleton G10))))) 
+        (first _ : Fin (lgti (singleton G01)))).
+      * apply GeqPerm0_intro.
+        -- reflexivity.
+        -- apply (IlistPerm3_cons _ _ (first _: Fin (lgti (singleton G10))) 
+             (first _ : Fin (lgti (singleton (mk_Graph 1 (singleton G01)))))).
+           ++ assumption.
+           ++ cbn ; apply IlistPerm3nil.
+      * cbn ; apply IlistPerm3nil.
 Qed.
 
 CoFixpoint G01' : Graph nat := mk_Graph 0 (singleton G10')
@@ -863,23 +853,21 @@ with G10' : Graph nat := mk_Graph 1 (singleton G01').
 Lemma GPPerm_G01'_G10' : GPPerm eq G01' G10'.
 Proof.
   apply GPPerm_intro.
-  apply (is_Graph_in_Graph_Gene_indir _ (first _: Fin (lgti (sons G10')))).
-  apply (Graph_in_Graph_Gene_refl (GeqPerm_refl _)).
-
-  apply (is_Graph_in_Graph_Gene_indir _ (first _: Fin (lgti (sons G01')))).
-  apply (Graph_in_Graph_Gene_refl (GeqPerm_refl _)).
+  - apply (is_Graph_in_Graph_Gene_indir _ (first _: Fin (lgti (sons G10')))).
+    apply (Graph_in_Graph_Gene_refl (GeqPerm_refl _)).
+  - apply (is_Graph_in_Graph_Gene_indir _ (first _: Fin (lgti (sons G01')))).
+    apply (Graph_in_Graph_Gene_refl (GeqPerm_refl _)).
 Qed.
 
 Lemma Geq_G01_G01' : Geq eq G01 G01'.
 Proof.
   cofix Hc.
   apply Geq_intro.
-  reflexivity.
-  
+  { reflexivity. }  
   apply (is_ilist_rel _ _ _ (refl_equal _ : lgti (sons G01) = lgti (sons G01'))).
   intro i.
   apply Geq_intro.
-  reflexivity.
+  { reflexivity. }
   apply (is_ilist_rel _ _ _ (refl_equal _ : lgti (singleton G01) = lgti (singleton G01'))).
   intro i'.
   apply Hc.
@@ -889,12 +877,11 @@ Lemma Geq_G10_G10' : Geq eq G10 G10'.
 Proof.
   cofix Hc.
   apply Geq_intro.
-  reflexivity.
-  
+  { reflexivity. }  
   apply (is_ilist_rel _ _ _ (refl_equal _ : lgti (sons G10) = lgti (sons G10'))).
   intro i.
   apply Geq_intro.
-  reflexivity.
+  { reflexivity. }
   apply (is_ilist_rel _ _ _ (refl_equal _ : lgti (singleton G10) = lgti (singleton G10'))).
   intro i'.
   apply Hc.
@@ -907,29 +894,28 @@ Definition g2 : Graph nat := mk_Graph 3 (icons G01 (singleton (mk_Graph 2 (@inil
 Lemma GPPerm_g1_g2 : GPPerm eq g1 g2.
 Proof.
   apply GPPerm_intro.
-  apply is_Graph_in_Graph_Gene_dir.
-  apply GeqPerm_intro.
-  reflexivity.
-  apply (IlistPerm3_cons _ _ (first _: Fin (lgti (sons g1))) (succ (first _) : Fin (lgti (sons g2)))).
-  apply (GeqPerm_refl _).
-  apply (IlistPerm3_cons _ _ (first _: Fin (lgti (extroduce (sons g1) (first (lgti (singleton G01)))))) 
-    (first _ : Fin (lgti (extroduce (sons g2) (succ (first 0)))))).
-  apply GeqPerm_intro.
-  reflexivity.
-  apply (IlistPerm3_refl (GeqPermRel _)).
-  simpl ; apply IlistPerm3nil.
-
-  apply is_Graph_in_Graph_Gene_dir.
-  apply GeqPerm_intro.
-  reflexivity.
-  apply (IlistPerm3_cons _ _ (succ (first _) : Fin (lgti (sons g2)))(first _: Fin (lgti (sons g1))) ).
-  apply (GeqPerm_refl _).
-  apply (IlistPerm3_cons _ _  (first _ : Fin (lgti (extroduce (sons g2) (succ (first 0)))))
-    (first _: Fin (lgti (extroduce (sons g1) (first (lgti (singleton G01))))))).
-  apply GeqPerm_intro.
-  reflexivity.
-  apply (IlistPerm3_refl (GeqPermRel _)).
-  simpl ; apply IlistPerm3nil.
+  - apply is_Graph_in_Graph_Gene_dir.
+    apply GeqPerm_intro.
+    { reflexivity. }
+    apply (IlistPerm3_cons _ _ (first _: Fin (lgti (sons g1))) (succ (first _) : Fin (lgti (sons g2)))).
+    + apply (GeqPerm_refl _).
+    + apply (IlistPerm3_cons _ _ (first _: Fin (lgti (extroduce (sons g1) (first (lgti (singleton G01)))))) 
+        (first _ : Fin (lgti (extroduce (sons g2) (succ (first 0)))))).
+      * apply GeqPerm_intro.
+        { reflexivity. }
+        apply (IlistPerm3_refl (GeqPermRel _)).
+      * cbn ; apply IlistPerm3nil.
+  - apply is_Graph_in_Graph_Gene_dir.
+    apply GeqPerm_intro.
+    { reflexivity. }
+    apply (IlistPerm3_cons _ _ (succ (first _) : Fin (lgti (sons g2)))(first _: Fin (lgti (sons g1))) ).
+    + apply (GeqPerm_refl _).
+    + apply (IlistPerm3_cons _ _  (first _ : Fin (lgti (extroduce (sons g2) (succ (first 0)))))
+        (first _: Fin (lgti (extroduce (sons g1) (first (lgti (singleton G01))))))).
+      * apply GeqPerm_intro.
+        { reflexivity. }
+        apply (IlistPerm3_refl (GeqPermRel _)).
+      * cbn ; apply IlistPerm3nil.
 Qed.
 
 Definition g012 : Graph nat := 
@@ -941,18 +927,18 @@ Definition g021 : Graph nat :=
 Lemma GPPerm_g012_g021 : GPPerm eq g012 g021.
 Proof.
   assert (H : GeqPerm eq g012 g021).
-  apply GeqPerm_intro.
-  reflexivity.
-  apply (IlistPerm3_cons _ _ (first _ : Fin (lgti (sons g012))) 
-    (succ (first _) : Fin (lgti (sons g021))) (GeqPerm_refl _ _)).
-  apply (IlistPerm3_cons _ _ (first _ : Fin (lgti (extroduce (sons g012)
-     (first (lgti (singleton _)))))) (first _ : Fin (lgti (extroduce (sons g021) (succ (first 0)))))
-     (GeqPerm_refl _ _)).
-  apply IlistPerm3_nil ; reflexivity.
-
+  { apply GeqPerm_intro.
+    { reflexivity. }
+    apply (IlistPerm3_cons _ _ (first _ : Fin (lgti (sons g012))) 
+        (succ (first _) : Fin (lgti (sons g021))) (GeqPerm_refl _ _)).
+    apply (IlistPerm3_cons _ _ (first _ : Fin (lgti (extroduce (sons g012)
+         (first (lgti (singleton _)))))) (first _ : Fin (lgti (extroduce (sons g021) (succ (first 0)))))
+         (GeqPerm_refl _ _)).
+    apply IlistPerm3_nil ; reflexivity.
+  }
   apply GPPerm_intro ; 
-  apply is_Graph_in_Graph_Gene_dir.
-  assumption.
+    apply is_Graph_in_Graph_Gene_dir.
+  { assumption. }
   apply (GeqPerm_sym _ H).
 Qed.
 
@@ -970,25 +956,25 @@ Proof.
   unfold node_in.
   exists g'.
   split.
-  assumption.
-  reflexivity.
+  - assumption.
+  - reflexivity.
 Qed.
 
 Lemma not_GPPerm_g3_g4 : not (GPPerm eq g3 g4).
 Proof.
   intros [[H1|i H1] _].
   destruct (GeqPerm_out H1) as [_ [_ e2 | i1 i2 H3 _]].
-  inversion e2.
-  destruct (GeqPerm_out H3) as [H5 _].
-  inversion H5.
-
-  revert H1.
-  fix Hr 1.
-  intros [H| i'' [H |i''' H]].
-  destruct (GeqPerm_out H) as [H' _].
-  inversion H'.
-  destruct (GeqPerm_out H) as [H' _].
-  inversion H'.
-  apply (Hr H).
+  - inversion e2.
+  - destruct (GeqPerm_out H3) as [H5 _].
+    inversion H5.
+  - revert H1.
+    fix Hr 1.
+    intros [H| i'' [H |i''' H]].
+    + destruct (GeqPerm_out H) as [H' _].
+      inversion H'.
+    + destruct (GeqPerm_out H) as [H' _].
+      inversion H'.
+    + apply (Hr H).
 Qed.
+
 End Example_GPPerm.

--- a/GPerm.v
+++ b/GPerm.v
@@ -474,7 +474,7 @@ Section GeqPerm.
    Lemma TeqPermn_antitone (g1 g2: Graph T)(m n: nat)(Hyp: m <= n):
      TeqPermn n g1 g2 -> TeqPermn m g1 g2.
    Proof. 
-     induction Hyp as [_ | n H1 IH]; intro H2.
+     induction Hyp as [| n H1 IH]; intro H2.
      assumption.
      apply IH.
      apply TeqPermn_Sn_n, H2.

--- a/GPermBij.v
+++ b/GPermBij.v
@@ -30,11 +30,11 @@ Section GeqPerm2.
   Proof.
     cofix Hc ; intros g.
     apply GeqPerm2_intro.
-    reflexivity.
-    apply (@perm7 _ _ _ _ (fun x => x) (fun x => x)).
-    split ; reflexivity.
-    intro i.
-    apply Hc.
+    - reflexivity.
+    - apply (@perm7 _ _ _ _ (fun x => x) (fun x => x)).
+      + split ; reflexivity.
+      + intro i.
+        apply Hc.
   Qed.
   
   Lemma GeqPerm2_sym(Rsym : Symmetric RelT): forall g1 g2, GeqPerm2 g1 g2 -> GeqPerm2 g2 g1.
@@ -42,13 +42,13 @@ Section GeqPerm2.
     cofix Hc.
     intros _ _ [g1 g2 h1 [f g h2 h3]].
     apply GeqPerm2_intro ; simpl in *|-*.
-    symmetry ; assumption.
-    apply (perm7 _ _ _ (Bij_sym h2)).
-    intro i.
-    apply Hc.
-    destruct h2 as [_ h2].
-    rewrite <- (h2 i) at 2.
-    apply h3.
+    - symmetry ; assumption.
+    - apply (perm7 _ _ _ (Bij_sym h2)).
+      intro i.
+      apply Hc.
+      destruct h2 as [_ h2].
+      rewrite <- (h2 i) at 2.
+      apply h3.
   Qed.
 
   Lemma GeqPerm2_trans(Rtrans : Transitive RelT): 
@@ -59,11 +59,10 @@ Section GeqPerm2.
     destruct h1 as [g1 g2 h1 [f1 gg1 h3 h4]].
     destruct h2 as [g2 g3 h2 [f2 gg2 h5 h6]].
     apply GeqPerm2_intro ; simpl in *|-*.
-    transitivity (label g2) ; assumption.
-    
-    apply (perm7 _ _ _ (Bij_trans h3 h5)).
-    intros i.
-    apply (Hc _ (fcti (sons g2) (f1 i)) _ (h4 _) (h6 _)).
+    - transitivity (label g2) ; assumption.
+    - apply (perm7 _ _ _ (Bij_trans h3 h5)).
+      intros i.
+      apply (Hc _ (fcti (sons g2) (f1 i)) _ (h4 _) (h6 _)).
   Qed.
   
   Add Parametric Relation (Req: Equivalence RelT): (Graph T)(GeqPerm2) 
@@ -89,10 +88,10 @@ Section GeqPerm2.
     cofix Hc.
     intros _ _ [g1 g2 R h1 h2 [f g h3 h4]].
     apply GeqPerm2_intro.
-    assumption.
-    apply (perm7 _ _ _ h3).
-    intro i.
-    apply Hc, h1, h4.
+    - assumption.
+    - apply (perm7 _ _ _ h3).
+      intro i.
+      apply Hc, h1, h4.
   Qed.
   
   Lemma GeqPerm2_GeqPerm1': subrelation GeqPerm2 GeqPerm1'.
@@ -107,8 +106,8 @@ Section GeqPerm2.
     cofix Hc.
     intros _ _ [g1 g2 h1 h2] .
     apply (GeqPerm1'_intro _ _ Hc).
-    assumption.
-    apply IlistPerm3_IlistPerm7, h2.
+    - assumption.
+    - apply IlistPerm3_IlistPerm7, h2.
   Qed.
 
   Lemma GeqPerm0_GeqPerm2: subrelation (GeqPerm0 RelT) GeqPerm2.
@@ -121,9 +120,9 @@ Section GeqPerm2.
     cofix Hc.
     intros _ _ [g1 g2 R h1 h2 h3] .
     apply (GeqPerm1_intro _ _ Hc).
-    assumption.
-    apply IlistPerm7_IlistPerm3.
-    apply (IlistPerm7_mon h1), h3.
+    - assumption.
+    - apply IlistPerm7_IlistPerm3.
+      apply (IlistPerm7_mon h1), h3.
   Qed.
   
   Lemma GeqPerm1_GeqPerm1': subrelation (GeqPerm1 RelT) GeqPerm1'.
@@ -131,9 +130,9 @@ Section GeqPerm2.
     cofix Hc.
     intros _ _ [g1 g2 R h1 h2 h3] .
     apply (GeqPerm1'_intro _ _ Hc).
-    assumption.
-    apply IlistPerm3_IlistPerm7.
-    apply (IlistPerm3_mon h1), h3.
+    - assumption.
+    - apply IlistPerm3_IlistPerm7.
+      apply (IlistPerm3_mon h1), h3.
   Qed.
   
   Lemma GeqPerm_GeqPerm2: subrelation (GeqPerm RelT) GeqPerm2.

--- a/Graphs.v
+++ b/Graphs.v
@@ -53,7 +53,7 @@ Section Graphs_def_tools.
       cofix coIH.
       intros [lab l].
       apply Geq_intro.
-      reflexivity.
+      { reflexivity. }
       apply (is_ilist_rel Geq l l (refl_equal _)).
       intro i.
       apply coIH.
@@ -66,10 +66,9 @@ Section Graphs_def_tools.
       intros _ _ g3 [[t1 l1] g2 e1 [e1' h1]] h2 ; 
         destruct h2 as [[t2 l2] [t3 l3] e2 [e2' h2]].
       apply Geq_intro.
-      apply (Rtrans _ t2) ; assumption.
-      simpl in *|-*.
+      { apply (Rtrans _ t2) ; assumption. }
+      cbn in *|-*.
       apply (is_ilist_rel Geq _ _ (trans_eq e1' e2')).
-      
       intro i.
       assert (h3 : rewriteFins (eq_trans e1' e2') i =  
         rewriteFins e2' (rewriteFins e1' i)) by treatFinPure.
@@ -82,8 +81,8 @@ Section Graphs_def_tools.
     Proof.
       cofix coIH.
       intros _ _ [[t1 l1] [t2 l2] e1 [e2 h1]].
-      apply Geq_intro ; simpl in *|-*.
-      apply Rsym, e1.
+      apply Geq_intro ; cbn in *|-*.
+      { apply Rsym, e1. }
       apply (is_ilist_rel _ _ _ (sym_eq e2)).
       intro i.
       assert (h2 := h1 (rewriteFins (eq_sym e2) i)).
@@ -139,12 +138,13 @@ Section Graphs_def_tools.
     cofix coIH.
     destruct g; intros f h.
     inversion_clear h as (a, H).
-    simpl in H.
-    apply is_wfG; simpl.
+    cbn in H.
+    apply is_wfG; cbn.
     inversion_clear i as (n', iln).
-    unfold iall; simpl; intro fi.
+    unfold iall; cbn; intro fi.
     apply (coIH _ _ (H fi)).
   Qed.
+  
   End wf_def_tools.
 
   Section Graph_in_Graph.
@@ -164,9 +164,9 @@ Section Graphs_def_tools.
       intros g1 g2 Heq H.
       revert g2 Heq.
       induction H as [g1 f H | g1 f H IH]; intros y Heq ;
-      destruct Heq as [g1 g2 e1 [e2 Heq]].
-      apply (is_Graph_in_Graph_dir g2 (rewriteFins e2 f) (Geq_trans _ H (Heq f))).
-      apply (is_Graph_in_Graph_indir g2 (rewriteFins e2 f) (IH _ (Heq f))).
+        destruct Heq as [g1 g2 e1 [e2 Heq]].
+      - apply (is_Graph_in_Graph_dir g2 (rewriteFins e2 f) (Geq_trans _ H (Heq f))).
+      - apply (is_Graph_in_Graph_indir g2 (rewriteFins e2 f) (IH _ (Heq f))).
     Qed.
 
     Add Parametric Morphism (RelT: relation T)(Req: Equivalence RelT)(g: Graph) : 
@@ -176,8 +176,8 @@ Section Graphs_def_tools.
       intros g1 g2 Heq H.
       revert g2 Heq.
       induction H as [g f H | g f H IH]; intros g2 Heq.
-      apply (is_Graph_in_Graph_dir g f (Geq_trans _ (Geq_sym _ Heq) H)).
-      apply (is_Graph_in_Graph_indir g f (IH _ Heq)).
+      - apply (is_Graph_in_Graph_dir g f (Geq_trans _ (Geq_sym _ Heq) H)).
+      - apply (is_Graph_in_Graph_indir g f (IH _ Heq)).
     Qed.
 
     (* Lemma to validate the definitions *)
@@ -193,9 +193,9 @@ Section Graphs_def_tools.
     Proof.
       intros g1 g2 H f.
       induction H as [g2 f' H | g2 f' H IH]; apply (is_Graph_in_Graph_indir g2 f').
-      inversion_clear H as [x i _ [H2 H3]].
-      apply (is_Graph_in_Graph_dir _ (rewriteFins H2 f) (H3 _)).
-      apply IH.
+      - inversion_clear H as [x i _ [H2 H3]].
+        apply (is_Graph_in_Graph_dir _ (rewriteFins H2 f) (H3 _)).
+      - apply IH.
     Qed.
       
     (* Proof of preservation of transitivity for Graph_in_Graph *)
@@ -205,9 +205,9 @@ Section Graphs_def_tools.
     Proof.
       intros g1 g2 g3 H1 H2.
       induction H1 as [g2 f H1 | g2 f H1 IH1].
-      apply (Graph_in_GraphM2 _ (Geq_sym _ H1)).
-      apply (GinG_sons_in_Graph H2).
-      apply (IH1 (GinG_sons_in_Graph H2 f)).
+      - apply (Graph_in_GraphM2 _ (Geq_sym _ H1)).
+        apply (GinG_sons_in_Graph H2).
+      - apply (IH1 (GinG_sons_in_Graph H2 f)).
     Qed.
 
   Section Graph_in_Graph_gene.
@@ -247,10 +247,10 @@ Section Graphs_def_tools.
       Graph_in_Graph R g1 g2 -> GinG' R g1 g2.
     Proof.
       intros H ; induction H as [g2 i H1 |g2 i H1 IH].
-      apply (is_Graph_in_Graph_Gene_indir _ i).
-      apply (is_Graph_in_Graph_Gene_dir _ _ _ H1).
-      apply (is_Graph_in_Graph_Gene_indir _ i).
-      apply IH.
+      - apply (is_Graph_in_Graph_Gene_indir _ i).
+        apply (is_Graph_in_Graph_Gene_dir _ _ _ H1).
+      - apply (is_Graph_in_Graph_Gene_indir _ i).
+        apply IH.
     Qed.
   
     Add Parametric Morphism(RelT: relation T)(R_trans: Transitive RelT)(g: Graph) : 
@@ -260,10 +260,10 @@ Section Graphs_def_tools.
       intros g1 g2 Heq H.
       revert g2 Heq.
       induction H as [g1 H | g1 f H IH]; intros y Heq.
-      apply is_Graph_in_Graph_Gene_dir.
-      apply (Geq_trans _ H Heq).
-      destruct Heq as [g1 g2 e1 [e2 Heq]].
-      apply (is_Graph_in_Graph_Gene_indir g2 (rewriteFins e2 f) (IH _ (Heq f))).
+      - apply is_Graph_in_Graph_Gene_dir.
+        apply (Geq_trans _ H Heq).
+      - destruct Heq as [g1 g2 e1 [e2 Heq]].
+        apply (is_Graph_in_Graph_Gene_indir g2 (rewriteFins e2 f) (IH _ (Heq f))).
     Qed.
 
     Add Parametric Morphism (RelT: relation T)(Req: Equivalence RelT)(g: Graph) : 
@@ -273,8 +273,8 @@ Section Graphs_def_tools.
       intros g1 g2 Heq H.
       revert g2 Heq.
       induction H as [g H | g f H IH]; intros g2 Heq.
-      apply (is_Graph_in_Graph_Gene_dir _ _ _ (Geq_trans _ (Geq_sym _ Heq) H)).
-      apply (is_Graph_in_Graph_Gene_indir g f (IH _ Heq)).
+      - apply (is_Graph_in_Graph_Gene_dir _ _ _ (Geq_trans _ (Geq_sym _ Heq) H)).
+      - apply (is_Graph_in_Graph_Gene_indir g f (IH _ Heq)).
     Qed.
 
     Lemma GinG'_sons_in_Graph (RelT: relation T): forall g1 g2, 
@@ -282,9 +282,9 @@ Section Graphs_def_tools.
     Proof.
       intros g1 g2 H i.
       induction H as [g2 H | g2 i' H IH].
-      destruct H as [g1 g2 _ [H1 H2]].
-      apply (is_Graph_in_Graph_Gene_indir _ (rewriteFins H1 i)), is_Graph_in_Graph_Gene_dir, H2.
-      apply (is_Graph_in_Graph_Gene_indir _ i'), IH.
+      - destruct H as [g1 g2 _ [H1 H2]].
+        apply (is_Graph_in_Graph_Gene_indir _ (rewriteFins H1 i)), is_Graph_in_Graph_Gene_dir, H2.
+      - apply (is_Graph_in_Graph_Gene_indir _ i'), IH.
     Qed.
       
     Lemma GinG'_trans (R: relation T)(Req: Equivalence R)(g1 g2 g3: Graph ) : 
@@ -292,8 +292,8 @@ Section Graphs_def_tools.
     Proof.
       intros H1 H2.
       induction H1 as [g2 H1 |g2 i H1 IH].
-      apply (GinG'M2 _ (Geq_sym _ H1)), H2.
-      apply IH, GinG'_sons_in_Graph, H2.
+      - apply (GinG'M2 _ (Geq_sym _ H1)), H2.
+      - apply IH, GinG'_sons_in_Graph, H2.
     Qed.
     
   End GinG'.
@@ -342,8 +342,8 @@ Section Graphs_def_tools.
       intros g1 g2 H1 [g [H2 H3]].
       exists g.
       split.
-      assumption.
-      apply (Geq_trans _ (Geq_sym _ H1) H3).
+      - assumption.
+      - apply (Geq_trans _ (Geq_sym _ H1) H3).
     Qed.
 
     Lemma Geq_ilist_rel(RelT: relation T): forall g1 g2: Graph, Geq RelT g1 g2 -> 
@@ -364,13 +364,13 @@ Section Graphs_def_tools.
       destruct H2 as [g1 Hpb1 H2].
       unfold Geq_prop_morph in HypPg.
       apply is_Gall.
-      rewrite <- H1.
-      assumption.
-      destruct H1 as [g1 g2 _ [H3 H4]].
-      intro i.
-      assert (H5 : i = (rewriteFins H3 (rewriteFins (sym_eq H3) i))) by treatFinPure.
-      rewrite H5.
-      apply (Hcb _ _ (H4 _) (H2 _)).
+      - rewrite <- H1.
+       assumption.
+      - destruct H1 as [g1 g2 _ [H3 H4]].
+       intro i.
+       assert (H5 : i = (rewriteFins H3 (rewriteFins (sym_eq H3) i))) by treatFinPure.
+       rewrite H5.
+       apply (Hcb _ _ (H4 _) (H2 _)).
     Qed.
 
     (* Proof of the monotonicity of P_Finite *)
@@ -379,8 +379,8 @@ Section Graphs_def_tools.
     Proof.
       intros lg lg' g H1 [g' [H2 H3]].
       exists g' ; split.
-      apply (H1 g' H2).
-      assumption.
+      - apply (H1 g' H2).
+      - assumption.
     Qed.
 
     (* Proof of the monotonicity of G_all with P_Finite *)
@@ -389,9 +389,9 @@ Section Graphs_def_tools.
     Proof.
       intros P P' g H1 ; revert g ; cofix Hc ; intros _ [g H2 H3].
       apply is_Gall.
-      apply H1, H2.
-      intro i.
-      apply (Hc _ (H3 i)).
+      - apply H1, H2.
+      - intro i.
+        apply (Hc _ (H3 i)).
     Qed.
 
     Lemma G_all_P_Finite_monotone (RelT: relation T): forall (lg lg':list Graph)(g: Graph),
@@ -417,23 +417,23 @@ Section Graphs_def_tools.
       intros H.
       destruct l as [n l] ; fold (mkilist l) in *|-*.
       induction n as [|n IH].
-      exists nil.
-      intro i.
-      inversion i.
-      assert (H1 : iall (G_finite RelT) (mkilist (fun x => l (succ x)))).
-      intro i.
-      apply (H (succ i)).
-      destruct (IH _ H1) as [lg H2].
-      destruct (H (first n)) as [lg' H3].
-      exists (lg' ++ lg).
-      unfold iall.
-      intro i.
-      elim (zerop (decode_Fin i)) ; intros H4.
-      rewrite (decode_Fin_0_first _ H4).
-      apply (G_all_P_Finite_monotone (incl_appl lg (incl_refl _))), H3.
-      apply (G_all_P_Finite_monotone (incl_appr lg' (incl_refl _))).
-      rewrite (decode_Fin_unique _ _ (decode_Fin_get_cons _ H4 : _ = decode_Fin (succ _))).
-      apply (H2 (get_cons i H4)).
+      - exists nil.
+        intro i.
+        inversion i.
+      - assert (H1 : iall (G_finite RelT) (mkilist (fun x => l (succ x)))).
+        { intro i.
+          apply (H (succ i)). }
+        destruct (IH _ H1) as [lg H2].
+        destruct (H (first n)) as [lg' H3].
+        exists (lg' ++ lg).
+        unfold iall.
+        intro i.
+        elim (zerop (decode_Fin i)) ; intros H4.
+        + rewrite (decode_Fin_0_first _ H4).
+          apply (G_all_P_Finite_monotone (incl_appl lg (incl_refl _))), H3.
+        + apply (G_all_P_Finite_monotone (incl_appr lg' (incl_refl _))).
+          rewrite (decode_Fin_unique _ _ (decode_Fin_get_cons _ H4 : _ = decode_Fin (succ _))).
+          apply (H2 (get_cons i H4)).
     Qed.
 
     (* Proof that if and only if g is finite, 
@@ -443,21 +443,20 @@ Section Graphs_def_tools.
     Proof.
       split ;
       intros H.
-      intro f.
-      destruct H as [lg H].
-      apply (is_Gfinite (lg := lg)).
-      destruct H as [g _ H2].
-      apply (H2 f).
-      
-      destruct (collectLists_G' _ H) as [lg H1].
-      apply (is_Gfinite (lg := g :: lg)).
-      apply is_Gall.
-      exists g.
-      split.
-      apply in_eq.
-      apply (Geq_refl _).
-      intro i. 
-      apply (G_all_P_Finite_monotone (incl_tl _ (incl_refl lg))), H1.
+      - intro f.
+        destruct H as [lg H].
+        apply (is_Gfinite (lg := lg)).
+        destruct H as [g _ H2].
+        apply (H2 f).
+      - destruct (collectLists_G' _ H) as [lg H1].
+        apply (is_Gfinite (lg := g :: lg)).
+        apply is_Gall.
+        + exists g.
+          split.
+          * apply in_eq.
+          * apply (Geq_refl _).
+        + intro i. 
+          apply (G_all_P_Finite_monotone (incl_tl _ (incl_refl lg))), H1.
     Qed.
 
     Lemma G_all_G_in_G_P(RelT: relation T)(Req: Equivalence RelT): 
@@ -467,11 +466,11 @@ Section Graphs_def_tools.
       intros P HypP _ [g _ Hall] gin Hin.
       unfold Geq_prop_morph in HypP.
       induction Hin as [g f Hin | g f Hin IH].
-      rewrite <- (Geq_sym _ Hin).
-      destruct (Hall f) as [g' HPg _].
-      assumption.
-      destruct (Hall f) as [g'  _ H].
-      apply (IH H).
+      - rewrite <- (Geq_sym _ Hin).
+        destruct (Hall f) as [g' HPg _].
+        assumption.
+      - destruct (Hall f) as [g'  _ H].
+        apply (IH H).
     Qed.
 
     Lemma G_finite_All_G_in_G_finite (RelT: relation T)(Req: Equivalence RelT): 
@@ -490,9 +489,9 @@ Section Graphs_def_tools.
       intros g H1 gin H2.
       induction H2 as [g f H3 | g f _ IH] ; 
       destruct (GinG_finite_ci _ g) as [H2 _].
-      apply (G_Finite_Geq_eq _ (Geq_sym _ H3)).
-      apply (H2 H1 f).
-      apply (IH (H2 H1 f)).
+      - apply (G_Finite_Geq_eq _ (Geq_sym _ H3)).
+        apply (H2 H1 f).
+      - apply (IH (H2 H1 f)).
     Qed.
 
   End Finite_def_tools.
@@ -518,10 +517,10 @@ Section Graphs_of_nat.
       cofix Hc.
       intros _ [g [g' [H1 H2]] H].
       apply is_Gall.
-      rewrite (hm _ _ H2).
-      apply (max_list_max (map f lg) _ (in_map _ _ _ H1)).
-      intro i.
-      apply (Hc _ (H i)).
+      - rewrite (hm _ _ H2).
+        apply (max_list_max (map f lg) _ (in_map _ _ _ H1)).
+      - intro i.
+        apply (Hc _ (H i)).
     Qed.
 
     Lemma morph_f_label_nat : morph_f (Geq (@eq nat)) (@label nat).
@@ -621,20 +620,20 @@ Section Examples.
         finite_example :: (mk_Graph 1 (singleton finite_example)) ::nil)).
       cofix Hc.
       apply is_Gall.
-      exists finite_example.
-      split.
-      apply in_eq.
-      apply (Geq_refl _).
-      intro f.
-      apply is_Gall.
-      exists (fcti (sons finite_example) (first 0)).
-      split.
-      right ; left; reflexivity.
-      apply (Geq_refl _).
-      unfold iall.
-      simpl.
-      intro f'.
-      apply Hc.
+      - exists finite_example.
+        split.
+        + apply in_eq.
+        + apply (Geq_refl _).
+      - intro f.
+        apply is_Gall.
+        + exists (fcti (sons finite_example) (first 0)).
+          split.
+          * right ; left; reflexivity.
+          * apply (Geq_refl _).
+        + unfold iall.
+          cbn.
+          intro f'.
+          apply Hc.
     Qed.
 
     Definition finite_example_unfolded: Graph nat.
@@ -649,10 +648,10 @@ Section Examples.
     Proof.
       cofix Hc.
       assert (H :forall (T: Set) (a1 a2: T), lgti (singleton a1) = lgti (singleton a2)).
-      intros T a1 a2 ; reflexivity.
-      do 4 (apply Geq_intro ; try reflexivity ; simpl ; 
+      { intros T a1 a2 ; reflexivity. }
+      do 4 (apply Geq_intro ; try reflexivity ; cbn ; 
         apply (is_ilist_rel _ _ _ (H _ _ _)) ; 
-        simpl ; intro f ; clear f).
+        cbn ; intro f ; clear f).
       apply Hc.
     Qed.
 
@@ -689,12 +688,12 @@ Section Examples.
     Proof.
       intros n m H.
       induction m as [| m IHm].
-      inversion H.
+      { inversion H. }
       elim (le_lt_eq_dec n m (lt_n_Sm_le _ _ H)); intros h.
-      apply (Graph_in_Graph_trans (@eq_equivalence _) (infinite_graph_gene_Sn_in_n m) 
-        (IHm h)).
-      rewrite h.
-      apply infinite_graph_gene_Sn_in_n.
+      - apply (Graph_in_Graph_trans (@eq_equivalence _) (infinite_graph_gene_Sn_in_n m) 
+          (IHm h)).
+      - rewrite h.
+       apply infinite_graph_gene_Sn_in_n.
     Qed.
 
     Lemma infinite_example_gene_unbounded : forall n: nat, 
@@ -703,10 +702,10 @@ Section Examples.
       intros n [m H].
       inversion H as [g h H0 e].
       clear g e H0.
-      simpl in *|-*.
+      cbn in *|-*.
       assert (Hin := infinite_example_gene_n_inc_all (le_gt_S _ _ h)).
       assert (S m <= m).
-      apply (G_all_G_in_G_P (@eq_equivalence _) (@Pg_label_boundM m) H Hin).
+      { apply (G_all_G_in_G_P (@eq_equivalence _) (@Pg_label_boundM m) H Hin). }
       apply (le_Sn_n _ H0).
     Qed.
   
@@ -740,8 +739,8 @@ Section Examples.
       cofix Hc.
       intros n m.
       destruct m as [| m].
-      exact (add11 (Hc (S n) (S n))).
-      exact (mk_Graph 0 (singleton (Hc n m))).
+      - exact (add11 (Hc (S n) (S n))).
+      - exact (mk_Graph 0 (singleton (Hc n m))).
     Defined.
 
 
@@ -763,75 +762,66 @@ Section Examples.
     (forall (n:nat), n <= length lg -> ~~P_Finite (@eq _) lg (seq n)) -> False.
   Proof.
     induction lg as [|g lg IH]; intros seq H1 H2.
-    apply (H2 0 (le_refl 0)).
-    intros [g [H3 _]].
-    inversion H3.
-
-(* the following first part of the proof is based on a simple intuitive argument:
-   not all elements up to index length lg can be in P_Finite lg, 
-   hence one of them must be bisimilar with g
-*)
-
-    apply (IH _ H1).
-    intros n H3 H4.
-
-    apply (H2 _ (lt_le_weak _ _ (le_lt_n_Sm _ _ H3))) ; intro H0.
-
-    assert (H5: Geq (@eq _) (seq n) g).
-    destruct H0 as [g' [[H5|H5] H6]];
-    [rewrite H5 | destruct H4 ; exists g' ; split]; assumption.
-
-  
-(* also the following second  part of the proof is based on a simple intuitive argument:   
-   If we throw this element (seq x) out, the remaining sequence has all elements up to index 
-   length lg in P_Finite lg since g is already taken. Now, this is a contradiction.
-*)
+    - apply (H2 0 (le_refl 0)).
+      intros [g [H3 _]].
+      inversion H3.
+    - (* the following first part of the proof is based on a simple intuitive argument:
+         not all elements up to index length lg can be in P_Finite lg, 
+         hence one of them must be bisimilar with g
+       *)
+      apply (IH _ H1).
+      intros n H3 H4.
+      apply (H2 _ (lt_le_weak _ _ (le_lt_n_Sm _ _ H3))) ; intro H0.
+      assert (H5: Geq (@eq _) (seq n) g).
+      { destruct H0 as [g' [[H5|H5] H6]];
+          [rewrite H5 | destruct H4 ; exists g' ; split]; assumption. }  
+      (* also the following second part of the proof is based on a simple intuitive argument:   
+         If we throw this element (seq x) out, the remaining sequence has all elements up to index 
+         length lg in P_Finite lg since g is already taken. Now, this is a contradiction.
+       *)
  
-(* first some preparations *)
-   set (seq' := fun x: nat => if (le_lt_dec n x) then seq (S x) else seq x).
-   assert (seq'Prop: (forall x: nat, x < n -> seq' x = seq x) /\ 
-     (forall x: nat, n <= x -> seq' x = seq (S x))).
-   split ; intros x h ; unfold seq'; elim (le_lt_dec n x) ; intro a ; try reflexivity ; 
-   [assert (h1 := (le_lt_trans n x n a h)) | assert (h1 := (le_lt_trans n x n h a))] ; 
-   elim (lt_irrefl _ h1).
-   destruct seq'Prop as [seq'Prop1 seq'Prop2].
-
-   assert (H6 : (∀n m : nat, Geq (@eq _) (seq' n) (seq' (n + m)) → m = 0)).
-
-(* seq' is a sub-sequence of seq, so 
-  forall n m : nat, Geq (seq' n) (seq' (n + m)) -> m = 0
-   is a consequence of the same property for seq *)
-
-   intros n' m H6.
-   destruct (le_lt_dec n (n'+m)) as [h1|h1].
-   rewrite (seq'Prop2 _ h1) in H6.
-   destruct (le_lt_dec n n') as [h2 |h2].
-   rewrite (seq'Prop2 _ h2) in H6.
-   rewrite <- plus_Sn_m in H6.
-   apply (H1 (S n') _ H6).
-   rewrite (seq'Prop1 _ h2) in H6.
-   rewrite plus_n_Sm in H6.
-   elim (O_S _ (sym_eq (H1 _ _ H6))).
-   do 2 rewrite seq'Prop1 in H6 ; try exact h1 ; 
-   try exact (le_lt_trans _ _ _ (le_plus_l n' m) h1).
-   apply (H1 _ _ H6).
-
-(* we can now carry out the second step of the proof *)
-   apply (IH _ H6).
-   intros n' H7 H8.
-   destruct (le_lt_dec n n') as [h1|h1'];
-   [rewrite (seq'Prop2 _ h1) in H8 ; destruct (H2 (S n') (le_n_S _ _ H7))
-   | rewrite (seq'Prop1 _ h1') in H8 ; set (h1 := lt_le_weak _ _ h1'); 
-     destruct (H2 n' (le_S _ _ H7))];
-   intros  [g0 [[Hyp1|Hyp1] Hyp2]] ; apply H8;
-   try (exists g0 ; split; assumption) ; rewrite <- Hyp1 in Hyp2 ;
-   assert (H10:=(GeqRel_Transitive (@eq_equivalence _) H5 
-     (GeqRel_Symmetric (@eq_equivalence _) Hyp2)));
-   rewrite (le_plus_minus _ _ h1) in H10.
-   rewrite plus_n_Sm in H10.
-   elim (O_S _ (sym_eq (H1 _ _ H10))).
-   elim (lt_irrefl _ (le_lt_trans n n' n 
-     (not_minus_O_le _ _ (H1 _ _ (GeqRel_Symmetric (@eq_equivalence _) H10))) h1')).
+      (* first some preparations *)
+      set (seq' := fun x: nat => if (le_lt_dec n x) then seq (S x) else seq x).
+      assert (seq'Prop: (forall x: nat, x < n -> seq' x = seq x) /\ 
+         (forall x: nat, n <= x -> seq' x = seq (S x))).
+      { split ; intros x h ; unfold seq'; elim (le_lt_dec n x) ; intro a ; try reflexivity ; 
+          [assert (h1 := (le_lt_trans n x n a h)) | assert (h1 := (le_lt_trans n x n h a))] ; 
+            elim (lt_irrefl _ h1). }
+      destruct seq'Prop as [seq'Prop1 seq'Prop2].
+      assert (H6 : (∀n m : nat, Geq (@eq _) (seq' n) (seq' (n + m)) → m = 0)).
+      { (* seq' is a sub-sequence of seq, so 
+           forall n m : nat, Geq (seq' n) (seq' (n + m)) -> m = 0
+           is a consequence of the same property for seq *)
+        intros n' m H6.
+        destruct (le_lt_dec n (n'+m)) as [h1|h1].
+        + rewrite (seq'Prop2 _ h1) in H6.
+          destruct (le_lt_dec n n') as [h2 |h2].
+          * rewrite (seq'Prop2 _ h2) in H6.
+            rewrite <- plus_Sn_m in H6.
+            apply (H1 (S n') _ H6).
+          * rewrite (seq'Prop1 _ h2) in H6.
+            rewrite plus_n_Sm in H6.
+            elim (O_S _ (sym_eq (H1 _ _ H6))).
+        + do 2 rewrite seq'Prop1 in H6 ; try exact h1 ; 
+             try exact (le_lt_trans _ _ _ (le_plus_l n' m) h1).
+          apply (H1 _ _ H6).
+      }
+      (* we can now carry out the second step of the proof *)
+      apply (IH _ H6).
+      intros n' H7 H8.
+      destruct (le_lt_dec n n') as [h1|h1'];
+       [rewrite (seq'Prop2 _ h1) in H8 ; destruct (H2 (S n') (le_n_S _ _ H7))
+       | rewrite (seq'Prop1 _ h1') in H8 ; set (h1 := lt_le_weak _ _ h1'); 
+         destruct (H2 n' (le_S _ _ H7))];
+       intros  [g0 [[Hyp1|Hyp1] Hyp2]] ; apply H8;
+       try (exists g0 ; split; assumption) ; rewrite <- Hyp1 in Hyp2 ;
+       assert (H10:=(GeqRel_Transitive (@eq_equivalence _) H5 
+         (GeqRel_Symmetric (@eq_equivalence _) Hyp2)));
+       rewrite (le_plus_minus _ _ h1) in H10.
+      + rewrite plus_n_Sm in H10.
+        elim (O_S _ (sym_eq (H1 _ _ H10))).
+      + elim (lt_irrefl _ (le_lt_trans n n' n 
+         (not_minus_O_le _ _ (H1 _ _ (GeqRel_Symmetric (@eq_equivalence _) H10))) h1')).
 Qed.
 
   Lemma list_not_infinite: forall (lg: list (Graph nat))(seq: nat -> Graph nat),
@@ -868,11 +858,11 @@ Qed.
   Proof.
     intro n.
     induction m as [|m IHm].
-    apply inf_ex_bounded_gene_aux_0.
-    rewrite inf_ex_bounded_gene_aux_S.
-    rewrite IHm.
-    unfold addn011 at 2.
-    reflexivity.
+    - apply inf_ex_bounded_gene_aux_0.
+    - rewrite inf_ex_bounded_gene_aux_S.
+      rewrite IHm.
+      unfold addn011 at 2.
+      reflexivity.
   Qed.
     
   Lemma inf_ex_bounded_gene_addn011: forall n, 
@@ -888,30 +878,30 @@ Qed.
   Proof.
     intros g1 g2 n H.
     induction n as [|n IHn].
-    apply Geq_intro.
-    reflexivity.
-    assert (h : lgti (singleton g1) = lgti (singleton g2)).
-    reflexivity.
-    apply (is_ilist_rel _ _ _ h).
-    intro f.
-    assumption.
-    simpl.
-    apply Geq_intro.
-    reflexivity.
-    assert (h : lgti (singleton (addn011 n g1)) = lgti (singleton (addn011 n g2))).
-    reflexivity.
-    apply (is_ilist_rel _ _ _ h).
-    intro f.
-    assumption.
+    - apply Geq_intro.
+      { reflexivity. }
+      assert (h : lgti (singleton g1) = lgti (singleton g2)).
+      { reflexivity. }
+      apply (is_ilist_rel _ _ _ h).
+      intro f.
+      assumption.
+    - cbn.
+      apply Geq_intro.
+      { reflexivity. }
+      assert (h : lgti (singleton (addn011 n g1)) = lgti (singleton (addn011 n g2))).
+      { reflexivity. }
+      apply (is_ilist_rel _ _ _ h).
+      intro f.
+      assumption.
   Qed.
 
   Lemma addn0comp : forall (n1 n2: nat)(g: Graph nat),
     addn0 n1 (addn0 n2 g) = addn0 (n1+n2) g.
   Proof.
     induction n1 as [|n1 IHn].
-    reflexivity.
+    { reflexivity. }
     intros n2 g.
-    simpl.
+    cbn.
     rewrite IHn.
     reflexivity.
   Qed.
@@ -923,30 +913,30 @@ Qed.
     induction n as [|n IHn] ;
     inversion H as [g3 g4 e1 [e H1] h1 h2] ;
     clear g3 g4 e1 h1 h2.
-    assumption.
-    simpl in H1.
-    apply (IHn (H1 (first _))).
+    - assumption.
+    - cbn in H1.
+      apply (IHn (H1 (first _))).
   Qed.
 
   Lemma addn0_Geq: forall (n: nat)(g1 g2: Graph nat),
    Geq (@eq _) g1 g2 ->  Geq (@eq _) (addn0 n g1)(addn0 n g2).
   Proof.
     induction n as [|n IH]; intros g1 g2 H.
-    apply H.
-    apply Geq_intro.
-    reflexivity.
-    simpl.
-    apply (is_ilist_rel _ _ _ (refl_equal _ : 
-     lgti (singleton (addn0 n g1)) = lgti(singleton (addn0 n g2)))).
-    simpl.
-    intro i ; apply IH, H.
+    - apply H.
+    - apply Geq_intro.
+      { reflexivity. }
+      cbn.
+      apply (is_ilist_rel _ _ _ (refl_equal _ : 
+         lgti (singleton (addn0 n g1)) = lgti(singleton (addn0 n g2)))).
+      cbn.
+      intro i ; apply IH, H.
   Qed.
 
   Lemma inf_ex_bounded_gene_inj (n m: nat): 
     Geq (@eq _) (inf_ex_bounded_gene n)(inf_ex_bounded_gene (n+m)) -> m=0.
   Proof.
     destruct m.
-    reflexivity.
+    { reflexivity. }
     intro.
     rewrite inf_ex_bounded_gene_addn011 in H.
     rewrite (inf_ex_bounded_gene_addn011 (n + S m)) in H.
@@ -962,7 +952,7 @@ Qed.
   Proof.
     intros lg g n H.
     induction n as [|n IHn].
-    assumption.
+    { assumption. }
     inversion H as [g' Hp Hall e].
     apply (IHn (Hall (first 0))).
   Qed.
@@ -988,12 +978,12 @@ Qed.
   Proof.
     intros n lg Hyp m. revert n Hyp.
     induction m as [|m IHm]; intros n Hyp.
-    rewrite <- plus_n_O.
-    assumption.
-    rewrite <- plus_n_Sm.
-    assert (H:= IHm _ Hyp).
-    rewrite inf_ex_bounded_gene_addn011 in H.
-    apply (G_all_addn011_inv _ _ H).
+    - rewrite <- plus_n_O.
+      assumption.
+    - rewrite <- plus_n_Sm.
+      assert (H:= IHm _ Hyp).
+      rewrite inf_ex_bounded_gene_addn011 in H.
+      apply (G_all_addn011_inv _ _ H).
   Qed.
 
   Lemma inf_ex_bounded_geneelements: forall (n: nat)(lg: list (Graph nat)),
@@ -1014,12 +1004,12 @@ Qed.
       intros n H.
       inversion H as [lg Hall].
       apply (list_not_infinite (lg:=lg) (fun m:nat => inf_ex_bounded_gene (n+m))).
-      intros n' m H1.
-      rewrite plus_assoc in H1.
-      apply inf_ex_bounded_gene_inj in H1.
-      assumption.
-      intros n' Hle.
-      apply (inf_ex_bounded_geneelements _ Hall).
+      - intros n' m H1.
+        rewrite plus_assoc in H1.
+        apply inf_ex_bounded_gene_inj in H1.
+        assumption.
+      - intros n' Hle.
+        apply (inf_ex_bounded_geneelements _ Hall).
     Qed.
     
     Definition ilist_n0 (n: nat) := mkilist (fun i : Fin n => 0).
@@ -1032,7 +1022,8 @@ Qed.
       match g with 
         mk_Graph l _ => lgti l 
       end.
-    Lemma  inf_ex_bounded_gene'_Sn_n(n: nat): 
+    
+    Lemma  inf_ex_bounded_gene'_Sn_n (n: nat): 
       Graph_in_Graph eq (inf_ex_bounded_gene' (S n)) (inf_ex_bounded_gene' n).
     Proof.
       apply (is_Graph_in_Graph_dir _ (first _ : Fin (lgti (sons (inf_ex_bounded_gene' n))))).
@@ -1044,12 +1035,12 @@ Qed.
     Proof.
       intros H.
       induction m as [| m IHm].
-      inversion H.
+      { inversion H. }
       elim (le_lt_eq_dec n m (lt_n_Sm_le _ _ H)); intros h.
-      apply (Graph_in_Graph_trans (@eq_equivalence _) (inf_ex_bounded_gene'_Sn_n _)
-        (IHm h)).
-      rewrite h.
-      apply inf_ex_bounded_gene'_Sn_n.
+      - apply (Graph_in_Graph_trans (@eq_equivalence _) (inf_ex_bounded_gene'_Sn_n _)
+          (IHm h)).
+      - rewrite h.
+        apply inf_ex_bounded_gene'_Sn_n.
     Qed.
     
     Theorem inf_ex_bounded_gene'_infinite: forall (n: nat), 
@@ -1058,21 +1049,22 @@ Qed.
       intros n.
       assert (H1 := @infinite_unbounded _ eq (inf_ex_bounded_gene' n) nb_O).
       assert (H2 : morph_f (Geq eq) nb_O).
-      intros _ _ [[lab1 l1] [lab2 l2] H2 _].
-      simpl in *|-*.
-      rewrite H2.
-      reflexivity.
+      { intros _ _ [[lab1 l1] [lab2 l2] H2 _].
+        cbn in *|-*.
+        rewrite H2.
+        reflexivity. }
       apply (H1 H2) ; clear H1.
       intros [m H3].
       inversion H3.
       assert (H4 : S m <= m).
-      assert (H5 : forall m x y, Geq eq x y -> impl (nb_O x <= m) (nb_O y <= m)).
-      intros m' _ _ [[labx lx] [laby ly] H4 H5] H6.
-      simpl in *|-*.
-      rewrite <- H4 ; assumption.
-      rewrite (refl_equal _ : S m = nb_O (inf_ex_bounded_gene' (S m))).
-      apply (G_all_G_in_G_P _ (H5 m) H3).
-      apply inf_ex_bounded_gene'_m_n, le_gt_S, H.
+      { assert (H5 : forall m x y, Geq eq x y -> impl (nb_O x <= m) (nb_O y <= m)).
+        { intros m' _ _ [[labx lx] [laby ly] H4 H5] H6.
+          cbn in *|-*.
+          rewrite <- H4 ; assumption. }
+        rewrite (refl_equal _ : S m = nb_O (inf_ex_bounded_gene' (S m))).
+        apply (G_all_G_in_G_P _ (H5 m) H3).
+        apply inf_ex_bounded_gene'_m_n, le_gt_S, H.
+      }
       apply (le_Sn_n _ H4).
     Qed.
       
@@ -1112,14 +1104,14 @@ Lemma JustOneLeaf_finite (n: nat) : G_finite eq (JustOneLeaf n).
 Proof.
   apply (is_Gfinite (lg := JustOneLeaf n :: nil)).
   apply is_Gall.
-  exists (JustOneLeaf n).
-  split.
-  left ; reflexivity.
-  apply (Geq_refl _).
-  unfold iall.
-  simpl.
-  intro i.
-  inversion i.
+  - exists (JustOneLeaf n).
+    split.
+    + left ; reflexivity.
+    + apply (Geq_refl _).
+  - unfold iall.
+    cbn.
+    intro i.
+    inversion i.
 Qed.
 
 CoFixpoint three_nodes_graph: Graph nat :=
@@ -1150,12 +1142,12 @@ Proof.
   try assert (H2 := decode_Fin_unique _ _ (h: _ = decode_Fin (first _)) : f = first 1) ; 
   try assert (H2 := decode_Fin_unique _ _ (h: _ = decode_Fin (succ (first 0))) : 
     f = succ (first 0)) ; 
-  simpl in f, H ; rewrite H2 in H; clear f h H2 a;
+  cbn in f, H ; rewrite H2 in H; clear f h H2 a;
   try (inversion H as [g1 g2 e H1 H3 H4] ; inversion e) ; 
   try (destruct H as [f' | f'] ;
   rewrite (Fin_first_1 f') in H ; clear f' ; 
   try (inversion H as [g1 g2 e H1 H3 H4] ; inversion e)) ; 
-  try (destruct H as [[f H | f H] |f H] ; simpl in H ; rewrite (Fin_first_1 f) in H ; 
+  try (destruct H as [[f H | f H] |f H] ; cbn in H ; rewrite (Fin_first_1 f) in H ; 
     clear f) ; 
   try (inversion H as [g1 g2 e H1 H3 H4] ; inversion e) ; 
   try (destruct H as [[f H| f H] | f H] ; inversion f) ; 
@@ -1241,10 +1233,10 @@ Section hasCycle'.
     Proof.
       intros H.
       induction H as [g H |g i H IH].
-      apply (hasCycle'_intro H).
-      apply is_Graph_in_Graph_Gene_dir.
-      apply (Geq_refl _). 
-      apply (hasCycle'_sons _ _ _ IH).
+      - apply (hasCycle'_intro H).
+        apply is_Graph_in_Graph_Gene_dir.
+        apply (Geq_refl _). 
+      - apply (hasCycle'_sons _ _ _ IH).
     Qed.
     
     Add Parametric Morphism (T: Set)(RelT: relation T)(Req: Equivalence RelT) : 
@@ -1260,10 +1252,10 @@ Section hasCycle'.
     Proof.
       intros [g' H1 H2].
       induction H2 as [g H2 |g i H2 IH].
-      apply hasCycle_dir.
-      rewrite <- H2.
-      apply H1.
-      apply (hasCycle_indir _ i IH).
+      - apply hasCycle_dir.
+        rewrite <- H2.
+        apply H1.
+      - apply (hasCycle_indir _ i IH).
     Qed.
 
 End hasCycle'.

--- a/Graphs.v
+++ b/Graphs.v
@@ -1143,7 +1143,7 @@ Defined.
 
 Lemma three_nodes_graph_bis_not_hasCycle: not (hasCycle (@eq _) three_nodes_graph_bis).
 Proof.
-  intros [[f H |f H]| f H];
+  intros [[f  |f ]| f ];
   elim (zerop (decode_Fin f)) ; intros a ;
   try assert (h:= (le_antisym _ _ (gt_S_le _ _ (decode_Fin_inf_n f)) (gt_le_S _ _ a))) ;
   try assert (h := a) ; 
@@ -1152,10 +1152,10 @@ Proof.
     f = succ (first 0)) ; 
   simpl in f, H ; rewrite H2 in H; clear f h H2 a;
   try (inversion H as [g1 g2 e H1 H3 H4] ; inversion e) ; 
-  try (destruct H as [f' H | f' H] ;
+  try (destruct H as [f' | f'] ;
   rewrite (Fin_first_1 f') in H ; clear f' ; 
   try (inversion H as [g1 g2 e H1 H3 H4] ; inversion e)) ; 
-  try (destruct H as [[f H| f H] |f H] ; simpl in H ; rewrite (Fin_first_1 f) in H ; 
+  try (destruct H as [[f H | f H] |f H] ; simpl in H ; rewrite (Fin_first_1 f) in H ; 
     clear f) ; 
   try (inversion H as [g1 g2 e H1 H3 H4] ; inversion e) ; 
   try (destruct H as [[f H| f H] | f H] ; inversion f) ; 

--- a/IPPJustification.v
+++ b/IPPJustification.v
@@ -18,7 +18,7 @@ Require Import Logic.ChoiceFacts. (* this does not assume choice axioms but only
 
 Set Implicit Arguments.
 
-Fixpoint FinIndex (n: nat)(e: Fin n): nat :=
+Definition FinIndex (n: nat)(e: Fin n): nat :=
   match e with first m => m | @succ m e' => m end.
 
 (* an interactive definition: *)

--- a/IPPJustification.v
+++ b/IPPJustification.v
@@ -24,9 +24,7 @@ Definition FinIndex (n: nat)(e: Fin n): nat :=
 (* an interactive definition: *)
 Definition FinIndex_alt (n: nat)(e: Fin n): nat.
 Proof.
-  destruct e.
-  exact k.
-  exact k.
+  destruct e; exact k.
 Defined.
 
 Lemma FinIndex_alt_is_same (n: nat)(e: Fin n): FinIndex e = FinIndex_alt e.
@@ -44,10 +42,10 @@ Lemma FinIndexOkCor (n: nat)(e: Fin n):
   n-1 = FinIndex e.
 Proof.
   destruct n.
-  inversion e.
-  apply eq_add_S.
-  rewrite <- FinIndexOk.
-  destruct n; reflexivity.
+  - inversion e.
+  - apply eq_add_S.
+    rewrite <- FinIndexOk.
+    destruct n; reflexivity.
 Defined.
 
 Lemma SkAux (k: nat): S k - 1 = k.
@@ -69,11 +67,11 @@ e = rewriteFins (sym_eq(FinIndexOk e)) (first (FinIndex e))
 \/ exists e':(Fin(FinIndex e)), e = rewriteFins (sym_eq(FinIndexOk e))(succ e').
 Proof.
   induction e.
-  left.
-  reflexivity.
-  right.
-  exists e.
-  reflexivity.
+  - left.
+    reflexivity.
+  - right.
+    exists e.
+    reflexivity.
 Qed.
 
 Definition FinCasesAux (A: Type)(a: A)(n: nat)(f: Fin (n-1) -> A): Fin n -> A.
@@ -99,8 +97,8 @@ Definition FinCases' (A: Type)(a: A)(n: nat)(f: Fin n -> A): Fin (S n) -> A.
 Proof.
   intros i.
   elim (zerop (decode_Fin i)) ; intros H.
-  exact a.
-  exact (f (get_cons _ H)).
+  - exact a.
+  - exact (f (get_cons _ H)).
 Defined.
 
 Lemma FinCasesOK1 (A: Type)(a: A)(n: nat)(f: Fin n -> A):
@@ -123,23 +121,23 @@ Lemma FinCasesElim (A: Type)(a: A)(n: nat)(f: Fin n -> A)(R: Fin (S n) -> A -> P
 Proof.
   intros Hyp1 Hyp2 e.
   elim (zerop (decode_Fin e)) ; intros H.
-  rewrite (decode_Fin_0_first _ H).
-  rewrite FinCasesOK1.
-  assumption.
-  rewrite (decode_Fin_unique _ _ (decode_Fin_get_cons _ H : decode_Fin e = decode_Fin (succ _))).
-  rewrite FinCasesOK2.
-  apply Hyp2.
+  - rewrite (decode_Fin_0_first _ H).
+    rewrite FinCasesOK1.
+    assumption.
+  - rewrite (decode_Fin_unique _ _ (decode_Fin_get_cons _ H : decode_Fin e = decode_Fin (succ _))).
+    rewrite FinCasesOK2.
+    apply Hyp2.
 Qed.
 (* very bad situation where the support for Fin in Coq does not help *) 
   
 Lemma FinCases_FinCases'(A: Type)(a: A)(n: nat)(f: Fin n -> A) :
   forall i, FinCases a f i = FinCases' a f i.
 Proof.
-  intros i ; unfold FinCases' ; elim (zerop (decode_Fin i)) ; intros H ; simpl.
-  rewrite (decode_Fin_0_first _ H).
-  apply FinCasesOK1.
-  rewrite  (decode_Fin_unique _ _ (decode_Fin_get_cons _ H : _ = decode_Fin (succ _))) at 1.
-  apply FinCasesOK2.
+  intros i ; unfold FinCases' ; elim (zerop (decode_Fin i)) ; intros H ; cbn.
+  - rewrite (decode_Fin_0_first _ H).
+    apply FinCasesOK1.
+  - rewrite  (decode_Fin_unique _ _ (decode_Fin_get_cons _ H : _ = decode_Fin (succ _))) at 1.
+    apply FinCasesOK2.
 Qed.
 
 (* FinCases' will no longer be used *)
@@ -148,17 +146,17 @@ Lemma FunctionalChoiceFin (m: nat): FunctionalChoice_on (Fin m) nat.
 Proof.
   red.
   induction m ; intros R H.
-  exists (fun _ => 0).
-  intro x; inversion x.
-  set (R' := fun e => R (succ e)).
-  destruct (IHm R') as [f Hyp];
-  clear IHm.
-  intro x.
-  apply (H (succ x)).
-  destruct (H (first m)) as [y0 Hyp0].
-  clear H.
-  exists (FinCases y0 f).
-  apply FinCasesElim; assumption.
+  - exists (fun _ => 0).
+    intro x; inversion x.
+  - set (R' := fun e => R (succ e)).
+    destruct (IHm R') as [f Hyp];
+      clear IHm.
+    + intro x.
+      apply (H (succ x)).
+    + destruct (H (first m)) as [y0 Hyp0].
+      clear H.
+      exists (FinCases y0 f).
+      apply FinCasesElim; assumption.
 Qed.
 
 Definition IP3ClCases (n: nat)(f: IlistPerm3Cert_list n -> nat): IlistPerm3Cert_list (S n) -> nat.
@@ -175,9 +173,9 @@ Lemma ExclMiddleImpDNE: excluded_middle -> DNE.
 Proof.
   intros EM P H.
   destruct (EM P) as [H1|H1].
-  assumption.
-  apply False_rec.
-  contradiction H.
+  - assumption.
+  - apply False_rec.
+    contradiction H.
 Qed.
 
 Lemma DeMorganExists: DNE -> forall (A: Type)(P: A -> Prop), 
@@ -203,12 +201,12 @@ Fixpoint MaxFin (m: nat): (Fin m -> nat) -> nat :=
 Lemma MaxFinOk (m: nat)(f: Fin m -> nat)(e: Fin m): MaxFin f >= f e.
 Proof.
   revert f; induction e; intros.
-  simpl.
-  apply le_plus_l.
-  simpl.
-  eapply le_trans.
-  eapply (IHe (fun e: Fin k => f (succ e))).
-  apply le_plus_r.
+  - cbn.
+    apply le_plus_l.
+  - cbn.
+    eapply le_trans.
+    + eapply (IHe (fun e: Fin k => f (succ e))).
+    + apply le_plus_r.
 Qed.
 
 Definition MaxFin' (m: nat) (f: Fin m -> nat) : nat := max_list_nat (map f (makeListFin m)).
@@ -231,30 +229,32 @@ Proof.
   apply (DeMorganExists DNE).
   intro H.
   assert (H0: forall f0 : Fin m, exists k: nat, forall n: nat, P n f0 -> ~ n >= k).
-  intro.
-  assert (H1 := H f0). clear H.
-  apply (DeMorganExists DNE).
-  intro H2.
-  apply H1.
-  intro k.
-  apply (DeMorganExists DNE).
-  intro H4.
-  assert (H3 := H2 k). clear H2.
-  apply H3.
-  intros n Hyp1 Hyp2.
-  apply (H4 n).
-  split; assumption.
+  { intro.
+    assert (H1 := H f0). clear H.
+    apply (DeMorganExists DNE).
+    intro H2.
+    apply H1.
+    intro k.
+    apply (DeMorganExists DNE).
+    intro H4.
+    assert (H3 := H2 k). clear H2.
+    apply H3.
+    intros n Hyp1 Hyp2.
+    apply (H4 n).
+    split; assumption.
+  }
   clear H.
   apply FunctionalChoiceFin in H0.
   destruct H0 as [k' Hyp].
   assert (H: forall (n:nat), ~ n >= MaxFin' k').
-  intro n.
-  destruct (HH n) as [f fgood].
-  intros H.
-  apply (Hyp _ _ fgood).
-  apply (le_trans _ (MaxFin' k')).
-  apply MaxFin'Ok.
-  assumption.
+  { intro n.
+    destruct (HH n) as [f fgood].
+    intros H.
+    apply (Hyp _ _ fgood).
+    apply (le_trans _ (MaxFin' k')).
+    - apply MaxFin'Ok.
+    - assumption.
+  }
   apply (H (S (MaxFin' k'))).
   apply le_n_Sn.
 Qed.
@@ -278,11 +278,12 @@ Proof.
   intros.
   destruct HypB as [Hyp1 Hyp2].
   assert (H': forall n : nat, exists a : A, P n (f a)).
-  intro n.
-  destruct (H n) as [b bgood].
-  exists (g b).
-  rewrite Hyp2.
-  assumption.
+  { intro n.
+   destruct (H n) as [b bgood].
+   exists (g b).
+   rewrite Hyp2.
+   assumption.
+  }
   destruct (Hyp _ H') as [a0 a0good].
   exists (f a0).
   assumption.
@@ -297,11 +298,11 @@ Qed.
 Definition FmFnFmn (m n: nat) : Fin m * Fin n -> Fin (m * n).
 Proof.
   revert n ; induction m as [|m IH]; intros n [i1 i2].
-  inversion i1.
+  { inversion i1. }
   elim (zerop (decode_Fin i1)) ; intros H1.
-  apply (@code_Fin1 _ (decode_Fin i2)), lt_plus_trans, decode_Fin_inf_n.
-  apply (@code_Fin1 _ (decode_Fin (IH _ ((get_cons _ H1), i2)) + n)).
-  apply FmFnFmn_aux, decode_Fin_inf_n.
+  - apply (@code_Fin1 _ (decode_Fin i2)), lt_plus_trans, decode_Fin_inf_n.
+  - apply (@code_Fin1 _ (decode_Fin (IH _ ((get_cons _ H1), i2)) + n)).
+    apply FmFnFmn_aux, decode_Fin_inf_n.
 Defined.
 
 Lemma FmnFmFn_aux(m n p : nat): p < S m * n -> n <= p -> p - n < m * n.
@@ -315,24 +316,24 @@ Qed.
 Definition FmnFmFn (m n: nat) : Fin (m * n) -> Fin m * Fin n.
 Proof.
   revert n ; induction m as [|m IH]; intros n i.
-  inversion i.
+  { inversion i. }
   elim (le_lt_dec n (decode_Fin i)) ; intros a.
-  assert (H1 := FmnFmFn_aux _ (decode_Fin_inf_n i) a).
-  exact (succ (fst (IH _ (code_Fin1 H1))), snd (IH _ (code_Fin1 H1))).
-  exact (first m, code_Fin1 a).
+  - assert (H1 := FmnFmFn_aux _ (decode_Fin_inf_n i) a).
+    exact (succ (fst (IH _ (code_Fin1 H1))), snd (IH _ (code_Fin1 H1))).
+  - exact (first m, code_Fin1 a).
 Defined.
 
 Lemma FmnFmFn_ok1 (m n :nat) (i: Fin ((S m)*n))(h1 : decode_Fin i < n): 
   FmnFmFn _ _ i = (first m, code_Fin1 h1).
 Proof.
-  simpl.
+  cbn.
   unfold sumbool_rec, sumbool_rect.
   set (x := le_lt_dec n (decode_Fin i)).
   change (le_lt_dec n (decode_Fin i)) with x.
   elim x ; intros a.
-  apply False_rec, (lt_irrefl n), (le_lt_trans _ _ _ a h1).
-  f_equal.
-  treatFinPure.
+  - apply False_rec, (lt_irrefl n), (le_lt_trans _ _ _ a h1).
+  - f_equal.
+    treatFinPure.
 Qed.
 
 
@@ -345,79 +346,79 @@ Proof.
   set (x := le_lt_dec n (decode_Fin i)).
   change (le_lt_dec n (decode_Fin i)) with x.
   elim x ; intros a.
-  do 3 f_equal ; try treatFinPure.
-  f_equal ; treatFinPure.
-  apply False_rec, (lt_irrefl n), (le_lt_trans _ _ _ h1 a).
+  - do 3 f_equal ; try treatFinPure.
+    + f_equal ; treatFinPure.
+  - apply False_rec, (lt_irrefl n), (le_lt_trans _ _ _ h1 a).
 Qed.
 
 Lemma FmFnFmn_ok1 (m n :nat) (i1: Fin (S m)) (i2 : Fin n)(h1 : decode_Fin i1 = 0): 
   FmFnFmn (i1, i2) = code_Fin1 (lt_plus_trans  _ _ (m*n) (decode_Fin_inf_n i2)).
 Proof.
-  simpl.
+  cbn.
   unfold sumbool_rec, sumbool_rect.
   elim (zerop (decode_Fin i1)) ; intros a.
-  treatFinPure.
-  apply False_rec, (lt_irrefl 0).
-  rewrite h1 in a.
-  assumption.
+  - treatFinPure.
+  - apply False_rec, (lt_irrefl 0).
+    rewrite h1 in a.
+    assumption.
 Qed.
   
 Lemma FmFnFmn_ok2 (m n :nat) (i1: Fin (S m)) (i2 : Fin n)(h1 : 0 < decode_Fin i1): 
   FmFnFmn (i1, i2) = code_Fin1 (FmFnFmn_aux _ _ (decode_Fin_inf_n (FmFnFmn (get_cons _ h1, i2)))).
 Proof.
-  simpl.
+  cbn.
   unfold sumbool_rec, sumbool_rect.
   elim (zerop (decode_Fin i1)) ; intros a.
-  apply False_rec, (lt_irrefl 0).
-  rewrite a in h1.
-  assumption.
-  assert (h2 : get_cons i1 a = get_cons i1 h1) by treatFinPure.
-  rewrite h2.
-  reflexivity.
+  - apply False_rec, (lt_irrefl 0).
+    rewrite a in h1.
+    assumption.
+  - assert (h2 : get_cons i1 a = get_cons i1 h1) by treatFinPure.
+    rewrite h2.
+    reflexivity.
 Qed.
 
 Lemma decode_FmFnFmn(m n: nat)(i1 : Fin m)(i2 : Fin n) : 
   decode_Fin (FmFnFmn (i1, i2)) = decode_Fin i1 * n + decode_Fin i2.
 Proof.
   induction m as [|m].
-  inversion i1.
+  { inversion i1. }
   elim (zerop (decode_Fin i1)) ; intros H1.
-  rewrite FmFnFmn_ok1 ; try assumption.
-  rewrite decode_code1_Id, H1.
-  rewrite mult_0_l.
-  rewrite plus_O_n; reflexivity.
-  rewrite (FmFnFmn_ok2 _ _ H1).
-  rewrite decode_code1_Id.
-  rewrite IHm.
-  rewrite (decode_Fin_get_cons _ H1).
-  simpl.
-  rewrite plus_comm.
-  apply plus_assoc.
+  - rewrite FmFnFmn_ok1 ; try assumption.
+    rewrite decode_code1_Id, H1.
+    rewrite mult_0_l.
+    rewrite plus_O_n; reflexivity.
+  - rewrite (FmFnFmn_ok2 _ _ H1).
+    rewrite decode_code1_Id.
+    rewrite IHm.
+    rewrite (decode_Fin_get_cons _ H1).
+    cbn.
+    rewrite plus_comm.
+    apply plus_assoc.
 Qed.
 
 Lemma decode_FmnFmFn(m n: nat)(i : Fin (m*n)) : 
   decode_Fin (fst (FmnFmFn _ _ i)) * n +  decode_Fin (snd (FmnFmFn _ _ i))= decode_Fin i.
 Proof.
   revert i ; induction m as [|m] ; intros i.
-  inversion i.
+  { inversion i. }
   elim (le_lt_dec n (decode_Fin i)) ; intros a.
-  rewrite (FmnFmFn_ok2 _ _ a).
-  simpl.
-  set (i' := code_Fin1 (FmnFmFn_aux m (decode_Fin_inf_n i) a)).
-  change (n + decode_Fin (fst (FmnFmFn m n i')) * n + decode_Fin (snd (FmnFmFn m n i')) =
+  - rewrite (FmnFmFn_ok2 _ _ a).
+    cbn.
+    set (i' := code_Fin1 (FmnFmFn_aux m (decode_Fin_inf_n i) a)).
+    change (n + decode_Fin (fst (FmnFmFn m n i')) * n + decode_Fin (snd (FmnFmFn m n i')) =
       decode_Fin i).
-  rewrite <- plus_assoc.
-  rewrite IHm.
-  unfold i'.
-  rewrite decode_code1_Id.
-  apply le_plus_minus_r, a.
-  
-  rewrite (FmnFmFn_ok1 _ _ a).
-  simpl.
-  apply decode_code1_Id.
+    rewrite <- plus_assoc.
+    rewrite IHm.
+    unfold i'.
+    rewrite decode_code1_Id.
+    apply le_plus_minus_r, a.
+  - rewrite (FmnFmFn_ok1 _ _ a).
+    cbn.
+    apply decode_code1_Id.
 Qed.
 
 Require Import Euclid.
+
 Lemma le_exists (n m : nat) : 0 < m -> m <= n -> exists x, exists y, y < m /\ n = x * m + y.
 Proof.
   intros H1 H2.
@@ -429,85 +430,82 @@ Qed.
 Lemma Fin_bij_mult (m n: nat): Bijective (@FmFnFmn m n) (@FmnFmFn m n).
 Proof.
   revert n ; induction m as [|m IH] ; intros n ; split ; try intros [i1 i2] ; try intros i.
-  inversion i1.
-  inversion i.
-
-  destruct (IH n) as [IH' _].
-  elim (zerop (decode_Fin i1)); intros a.
-  rewrite (FmFnFmn_ok1 _ _ a).
-  assert (H1 : decode_Fin (code_Fin1 (lt_plus_trans (decode_Fin i2) n (m * n) (decode_Fin_inf_n i2))) < n).
-  rewrite decode_code1_Id.
-  apply decode_Fin_inf_n.
-  rewrite (FmnFmFn_ok1 _ _ H1).
-  rewrite (decode_Fin_0_first _ a).
-  f_equal.
-  treatFinPure.
-  
-  rewrite (FmFnFmn_ok2 _ _ a).
-  assert (H1 : n <= decode_Fin (code_Fin1 (FmFnFmn_aux m n (decode_Fin_inf_n (FmFnFmn (get_cons i1 a, i2)))))).
-  rewrite decode_code1_Id.
-  apply le_plus_r.
-  rewrite (FmnFmFn_ok2 _ _ H1).
-  revert H1.
-  set (x := code_Fin1 (FmFnFmn_aux m n (decode_Fin_inf_n (FmFnFmn (get_cons i1 a, i2))))).
-  intros H1.
-  assert (H2 : FmnFmFn m n (code_Fin1 (FmnFmFn_aux m (decode_Fin_inf_n x) H1)) = (get_cons _ a, i2)).
-  rewrite <- IH'.
-  f_equal.
-  apply decode_Fin_unique.
-  unfold x.
-  repeat rewrite decode_code1_Id.
-  rewrite plus_comm.
-  apply minus_plus.
-  rewrite H2.
-  simpl.
-  rewrite <- (decode_Fin_unique _ _ (decode_Fin_get_cons _ a :_ =  decode_Fin (succ _))).
-  reflexivity.
-
-  apply decode_Fin_unique.
-  rewrite (surjective_pairing (FmnFmFn (S m) n i)).
-  rewrite decode_FmFnFmn.
-  apply decode_FmnFmFn.
+  - inversion i1.
+  - inversion i.
+  - destruct (IH n) as [IH' _].
+    elim (zerop (decode_Fin i1)); intros a.
+    + rewrite (FmFnFmn_ok1 _ _ a).
+      assert (H1 : decode_Fin (code_Fin1 (lt_plus_trans (decode_Fin i2) n (m * n) (decode_Fin_inf_n i2))) < n).
+      { rewrite decode_code1_Id.
+        apply decode_Fin_inf_n. }
+      rewrite (FmnFmFn_ok1 _ _ H1).
+      rewrite (decode_Fin_0_first _ a).
+      f_equal.
+      treatFinPure.
+    + rewrite (FmFnFmn_ok2 _ _ a).
+      assert (H1 : n <= decode_Fin (code_Fin1 (FmFnFmn_aux m n (decode_Fin_inf_n (FmFnFmn (get_cons i1 a, i2)))))).
+      { rewrite decode_code1_Id.
+        apply le_plus_r. }
+      rewrite (FmnFmFn_ok2 _ _ H1).
+      revert H1.
+      set (x := code_Fin1 (FmFnFmn_aux m n (decode_Fin_inf_n (FmFnFmn (get_cons i1 a, i2))))).
+      intros H1.
+      assert (H2 : FmnFmFn m n (code_Fin1 (FmnFmFn_aux m (decode_Fin_inf_n x) H1)) = (get_cons _ a, i2)).
+      { rewrite <- IH'.
+        f_equal.
+        apply decode_Fin_unique.
+        unfold x.
+        repeat rewrite decode_code1_Id.
+        rewrite plus_comm.
+        apply minus_plus.
+      }
+      rewrite H2.
+      cbn.
+      rewrite <- (decode_Fin_unique _ _ (decode_Fin_get_cons _ a :_ =  decode_Fin (succ _))).
+      reflexivity.
+  - apply decode_Fin_unique.
+    rewrite (surjective_pairing (FmnFmFn (S m) n i)).
+    rewrite decode_FmFnFmn.
+    apply decode_FmnFmFn.
 Qed.
 
 Lemma IlistPerm3Cert_list_bij_Fin (n: nat): exists m: nat, exists f: IlistPerm3Cert_list n -> Fin m, 
   exists g: Fin m -> IlistPerm3Cert_list n, Bijective f g.
 Proof.
   induction n.
-  exists 1.
-  exists (fun c: IlistPerm3Cert_list 0 => first 0), (fun f: Fin 1 => tt).
-  split; intro.
-  destruct t.
-  reflexivity.
-  apply sym_eq, Fin_first_1.
-  destruct IHn as [m0 [f0 [g0 HypB0]]].
-  simpl.
-  exists ((S n) * (S n) * m0).
-  rewrite <- mult_assoc.
-  exists (fun x => FmFnFmn ((fst (fst x)) , (FmFnFmn (snd (fst x), (f0 (snd x)))))),
-  (fun i => 
-    (fst (FmnFmFn _ _ i), fst (FmnFmFn _ _ (snd (FmnFmFn _ _ i))), g0 (snd (FmnFmFn _ _ (snd (FmnFmFn _ _ i)))))).
-  destruct (Fin_bij_mult (S n) (S n * m0)) as [Fb1 Fb2].
-  destruct (Fin_bij_mult (S n) m0) as [Fb1' Fb2'].
-  split.
-  intros [[i1 i2] s].
-  rewrite Fb1.
-  change ((i1, fst (FmnFmFn (S n) m0 (FmFnFmn (i2, f0 s))), g0 (snd (FmnFmFn (S n) m0 (FmFnFmn (i2, f0 s))))) = 
-    (i1, i2, s)).
-  rewrite Fb1'.
-  repeat f_equal.
-  apply HypB0.
-  
-  intros i.
-  change (FmFnFmn (fst (FmnFmFn (S n) (S n * m0) i), FmFnFmn
-    (fst (FmnFmFn (S n) m0 (snd (FmnFmFn (S n) (S n * m0) i))),
-    f0 (g0 (snd (FmnFmFn (S n) m0 (snd (FmnFmFn (S n) (S n * m0) i))))))) = i).
-  destruct HypB0 as [Hyp1 Hyp2].
-  rewrite Hyp2.
-  rewrite <- surjective_pairing.
-  rewrite Fb2'.
-  rewrite <- surjective_pairing.
-  apply Fb2.
+  - exists 1.
+    exists (fun c: IlistPerm3Cert_list 0 => first 0), (fun f: Fin 1 => tt).
+    split; intro.
+    + destruct t.
+      reflexivity.
+    + apply sym_eq, Fin_first_1.
+  - destruct IHn as [m0 [f0 [g0 HypB0]]].
+    cbn.
+    exists ((S n) * (S n) * m0).
+    rewrite <- mult_assoc.
+    exists (fun x => FmFnFmn ((fst (fst x)) , (FmFnFmn (snd (fst x), (f0 (snd x)))))),
+      (fun i => 
+        (fst (FmnFmFn _ _ i), fst (FmnFmFn _ _ (snd (FmnFmFn _ _ i))), g0 (snd (FmnFmFn _ _ (snd (FmnFmFn _ _ i)))))).
+    destruct (Fin_bij_mult (S n) (S n * m0)) as [Fb1 Fb2].
+    destruct (Fin_bij_mult (S n) m0) as [Fb1' Fb2'].
+    split.
+    + intros [[i1 i2] s].
+      rewrite Fb1.
+      change ((i1, fst (FmnFmFn (S n) m0 (FmFnFmn (i2, f0 s))), g0 (snd (FmnFmFn (S n) m0 (FmFnFmn (i2, f0 s))))) = 
+        (i1, i2, s)).
+      rewrite Fb1'.
+      repeat f_equal.
+      apply HypB0.
+    + intros i.
+      change (FmFnFmn (fst (FmnFmFn (S n) (S n * m0) i), FmFnFmn
+        (fst (FmnFmFn (S n) m0 (snd (FmnFmFn (S n) (S n * m0) i))),
+        f0 (g0 (snd (FmnFmFn (S n) m0 (snd (FmnFmFn (S n) (S n * m0) i))))))) = i).
+      destruct HypB0 as [Hyp1 Hyp2].
+      rewrite Hyp2.
+      rewrite <- surjective_pairing.
+      rewrite Fb2'.
+      rewrite <- surjective_pairing.
+      apply Fb2.
 Qed.
 
 Theorem IPPJustification: DNE -> IPPIlistPerm3Cert.

--- a/Ilist.v
+++ b/Ilist.v
@@ -262,10 +262,10 @@ Section ilist_def_tools.
     intros i n d h.
     unfold ilist2list.
     rewrite (nth_indep _ _ (fcti i (code_Fin1 h))).
-    rewrite map_nth, <- nth_makeListFin.
-    reflexivity.
-    rewrite map_length, makeListFin_nb_elem_ok.
-    assumption.
+    - rewrite map_nth, <- nth_makeListFin.
+      reflexivity.
+    - rewrite map_length, makeListFin_nb_elem_ok.
+      assumption.
   Qed.
 
   Lemma length_ilist2list: forall (i: ilist T), 
@@ -293,8 +293,8 @@ Section ilist_def_tools.
   Proof.
     intros t i f.
     assert (H: decode_Fin f < length (ilist2list i)).
-    rewrite length_ilist2list.
-    apply decode_Fin_inf_n.
+    { rewrite length_ilist2list.
+      apply decode_Fin_inf_n. }
     rewrite (nth_indep (ilist2list i) t (fcti i f) H).
     apply ilist2list_nth2.
   Qed.
@@ -307,8 +307,8 @@ Section ilist_def_tools.
   Definition list2Fin_T: forall (l: list T)(f: Fin (length l)), T.
   Proof.
     intros [| h l] f.
-    inversion f.
-    exact (nth (decode_Fin f) (h :: l) h).
+    - inversion f.
+    - exact (nth (decode_Fin f) (h :: l) h).
   Defined.
 
   Definition list2ilist (l: list T) : ilist T := mkilist (list2Fin_T l).
@@ -332,19 +332,19 @@ Section ilist_def_tools.
     intros l f.
     elim (gt_eq_gt_dec (decode_Fin f) 0) ; [intros [H|e] |intros a] ; try inversion H ;
     destruct l as [| h l].
-    inversion f.
-    left.
-    rewrite (decode_Fin_0_first _ e).
-    reflexivity.
-    inversion f.
-    right.
-    inversion a as [e | n H e]; 
-    refine (match e in (_ = df) return 
-      In match df with 0 => h | S m => nth m l h end l 
-      with refl_equal => _ end) ;
-    apply (nth_In _ _), lt_S_n ;
-    rewrite e ;
-    apply decode_Fin_inf_n.
+    - inversion f.
+    - left.
+      rewrite (decode_Fin_0_first _ e).
+      reflexivity.
+    - inversion f.
+    - right.
+      inversion a as [e | n H e]; 
+      refine (match e in (_ = df) return 
+        In match df with 0 => h | S m => nth m l h end l 
+        with refl_equal => _ end) ;
+      apply (nth_In _ _), lt_S_n ;
+      rewrite e ;
+      apply decode_Fin_inf_n.
   Qed.
 
   Definition inf_length_lgti: forall (n: nat)(l: list T)(h: n < length l),
@@ -360,30 +360,31 @@ Section ilist_def_tools.
     comp (nth n l t) (fcti (list2ilist l) (code_Fin1 (inf_length_lgti l h))).
   Proof.
     destruct n as [|n]; intros [| hd l] h t.
-    inversion h.
-    simpl.
-    rewrite code_Fin1_Sn_0.
-    reflexivity.
-    inversion h.
-    simpl in h.
-    simpl nth.
-    assert (h':= lt_le_S _ _ (lt_S_n _ _ h)).
-    assert (H: decode_Fin (code_Fin1_Sn (lt_n_Sm_le _ (length l) (inf_length_lgti (hd :: l) h)))= S n).
-    rewrite (code_Fin1_Sn_proofirr _ h').
-    revert n h h'.
-    induction (length l) as [| ll IHll] ; intros n h h'.
-    inversion h'.
-    rewrite code_Fin1_Sn_S.
-    simpl.
-    f_equal.
-    set (h1 := le_S_n _ _ h').
-    destruct n as [|n].
-    rewrite code_Fin1_Sn_0.
-    reflexivity.
-    apply (IHll _ (lt_S_n _ _ h)).
-    simpl.
-    rewrite H.
-    apply (nth_indep_comp _ l t hd h').
+    - inversion h.
+    - cbn.
+      rewrite code_Fin1_Sn_0.
+      reflexivity.
+    - inversion h.
+    - cbn in h.
+      simpl nth.
+      assert (h':= lt_le_S _ _ (lt_S_n _ _ h)).
+      assert (H: decode_Fin (code_Fin1_Sn (lt_n_Sm_le _ (length l) (inf_length_lgti (hd :: l) h)))= S n).
+      { rewrite (code_Fin1_Sn_proofirr _ h').
+        revert n h h'.
+        induction (length l) as [| ll IHll] ; intros n h h'.
+        - inversion h'.
+        - rewrite code_Fin1_Sn_S.
+          cbn.
+          f_equal.
+          set (h1 := le_S_n _ _ h').
+          destruct n as [|n].
+          + rewrite code_Fin1_Sn_0.
+            reflexivity.
+          + apply (IHll _ (lt_S_n _ _ h)).
+      }
+      cbn.
+      rewrite H.
+      apply (nth_indep_comp _ l t hd h').
   Qed.
     
   Lemma list2ilist_nth2: 
@@ -391,17 +392,17 @@ Section ilist_def_tools.
     nth (decode_Fin f) l t = fcti (list2ilist l) f.
   Proof.
     intros [|hd l] f t.
-    inversion f.
-    simpl.
-    simpl in f.
-    elim (gt_eq_gt_dec (decode_Fin f) 0); [intros [H|e] | intros a].
-    inversion H.
-    rewrite e; reflexivity.
-    inversion a as [e| n H e] ; assert (h:= decode_Fin_inf_n f) ; rewrite <- e in h.
-    destruct l as [|hhd l].
-    apply False_rec, (lt_irrefl _ h).
-    reflexivity.
-    apply (nth_indep_comp _ _ _ _ (lt_S_n _ _ h)).
+    - inversion f.
+    - cbn.
+      cbn in f.
+      elim (gt_eq_gt_dec (decode_Fin f) 0); [intros [H|e] | intros a].
+      + inversion H.
+      + rewrite e; reflexivity.
+      + inversion a as [e| n H e] ; assert (h:= decode_Fin_inf_n f) ; rewrite <- e in h.
+        * destruct l as [|hhd l].
+          -- apply False_rec, (lt_irrefl _ h).
+          -- reflexivity.
+        * apply (nth_indep_comp _ _ _ _ (lt_S_n _ _ h)).
   Qed.
 
   Lemma lgti_list2ilist: forall (l: list T), 
@@ -415,8 +416,8 @@ Section ilist_def_tools.
   Proof.
     intros i.
     assert (h : lgti (list2ilist (ilist2list i)) = lgti i).
-    rewrite lgti_list2ilist.
-    apply length_ilist2list.
+    { rewrite lgti_list2ilist.
+      apply length_ilist2list. }
     apply (is_ilist_rel _ _ _ h).
     intro f.
     rewrite <- (list2ilist_nth2 _ f (fcti _ f)), (decode_Fin_match' f h), <- (ilist2list_nth3 _).
@@ -432,15 +433,15 @@ Section ilist_def_tools.
   Lemma list2Fin_T_succ: forall (l: list T)(a: T)(x: Fin (length l)),
     (list2Fin_T (a :: l) (succ x)) = (list2Fin_T l x).
   Proof.
-   simpl.
+   cbn.
    induction l as [|hd l]; intros a f.
-   inversion f.
-   simpl.
-   set (d := decode_Fin f) ; assert (h1 := decode_Fin_inf_n f : d < (length (hd :: l))).
-   change (match d  with 0 => hd | S m => nth m l a end = match d with 0 => hd | S m => nth m l hd end ).
-   revert h1 ; generalize d; clear d ; intros [|d] h1.
-   reflexivity.
-   apply nth_indep, lt_S_n, h1.
+   - inversion f.
+   - cbn.
+     set (d := decode_Fin f) ; assert (h1 := decode_Fin_inf_n f : d < (length (hd :: l))).
+     change (match d  with 0 => hd | S m => nth m l a end = match d with 0 => hd | S m => nth m l hd end ).
+     revert h1 ; generalize d; clear d ; intros [|d] h1.
+     + reflexivity.
+     + apply nth_indep, lt_S_n, h1.
   Qed.
 
   Lemma list2Fin_T_succ_map: 
@@ -449,25 +450,25 @@ Section ilist_def_tools.
        map (fun x : Fin (length l) => list2Fin_T (a :: l) (succ x)) lf.
   Proof.
     intros l a ; induction lf as [| hd lf IH].
-    reflexivity.
-    change (list2Fin_T l hd :: map (fun x : Fin (length l) => list2Fin_T l x) lf = nth (decode_Fin hd) l a
-     :: map (fun x : Fin (length l) => list2Fin_T (a :: l) (succ x)) lf).
-    rewrite IH.
-    rewrite (list2ilist_nth2 l).
-    reflexivity.
+    - reflexivity.
+    - change (list2Fin_T l hd :: map (fun x : Fin (length l) => list2Fin_T l x) lf = nth (decode_Fin hd) l a
+       :: map (fun x : Fin (length l) => list2Fin_T (a :: l) (succ x)) lf).
+      rewrite IH.
+      rewrite (list2ilist_nth2 l).
+      reflexivity.
   Qed.
 
   Lemma ilist2list_list2ilist_id: forall (l: list T), ilist2list (list2ilist l) = l.
   Proof.
     induction l as [|hd l].
-    reflexivity.
-    rewrite <- IHl at 2.
-    unfold ilist2list, list2ilist.
-    change (hd :: map (list2Fin_T (hd :: l)) (map (fun x => @succ _ x) (makeListFin (length l))) = 
-      hd :: map (list2Fin_T l) (makeListFin (length l))).
-    rewrite map_map.
-    rewrite <- (list2Fin_T_succ_map l hd).
-    reflexivity.
+    - reflexivity.
+    - rewrite <- IHl at 2.
+      unfold ilist2list, list2ilist.
+      change (hd :: map (list2Fin_T (hd :: l)) (map (fun x => @succ _ x) (makeListFin (length l))) = 
+        hd :: map (list2Fin_T l) (makeListFin (length l))).
+      rewrite map_map.
+      rewrite <- (list2Fin_T_succ_map l hd).
+      reflexivity.
   Qed.
 
   Definition ilistM (n: nat)(i: ilistn T n): 
@@ -488,14 +489,14 @@ Section ilist_def_tools.
   Proof.
     intros T U l f i h.
     destruct l as [|t l].
-    inversion i.
-    simpl.
-    rewrite <- decode_Fin_match'.
-    elim (zerop (decode_Fin i)) ; intros a.
-    rewrite (decode_Fin_0_first _ a).
-    reflexivity.
-    inversion a ;
-    apply map_nth.
+    - inversion i.
+    - cbn.
+      rewrite <- decode_Fin_match'.
+      elim (zerop (decode_Fin i)) ; intros a.
+      + rewrite (decode_Fin_0_first _ a).
+        reflexivity.
+    + inversion a ;
+        apply map_nth.
   Qed.
 
   Lemma list2Fin_T_map_bis : forall (T U: Set)(l: list T)(f: T -> U)(i: Fin (length (map f l))),
@@ -503,103 +504,98 @@ Section ilist_def_tools.
   Proof.
     intros T U l f i.
     destruct l as [|t l].
-    inversion i.
-    simpl in *|-*.
-    rewrite <- decode_Fin_match'.
-    set (n := decode_Fin i) ; 
-    change (match n with | 0 => f t | S m => nth m (map f l) (f t) end = f match n with
-      | 0 => t | S m => nth m l t end).
-    destruct n as [|n].
-    reflexivity.
-    apply map_nth.
+    - inversion i.
+    - cbn in *|-*.
+      rewrite <- decode_Fin_match'.
+      set (n := decode_Fin i) ; 
+        change (match n with | 0 => f t | S m => nth m (map f l) (f t) end = f match n with
+          | 0 => t | S m => nth m l t end).
+      destruct n as [|n].
+      + reflexivity.
+      + apply map_nth.
   Qed.
 
   Lemma list2Fin_T_makeListFin: forall (T: Set)(l: ilist T)(i: Fin (length (makeListFin (lgti l))))
     (h:  length (makeListFin (lgti l)) = lgti l), 
     list2Fin_T (makeListFin (lgti l)) i = rewriteFins h i.
   Proof.
-    intros T [[|n] l] i h ; simpl in *|-* ; clear l ; 
+    intros T [[|n] l] i h ; cbn in *|-* ; clear l ; 
     apply decode_Fin_unique ; unfold rewriteFins ; rewrite <- decode_Fin_match.
-    inversion i.
-    set (d := decode_Fin i) ; assert (h1 := decode_Fin_inf_n i : d< _) ; assert (h2:= refl_equal _: d = decode_Fin i).
-    revert h1 h2 ; generalize d ; clear d ; intros [|d] h1 h2.
-    reflexivity.
-    assert (h3 : decode_Fin i > 0).
-    rewrite <- h2.
-    apply lt_0_Sn.
-    assert (i' := get_cons i h3).
-    rewrite map_length, makeListFin_nb_elem_ok in i'.
-    apply lt_S_n in h1.
-    rewrite (nth_indep _ (first n) (succ i') h1) , map_nth.
-    rewrite map_length, makeListFin_nb_elem_ok in h1.
-    rewrite <- (nth_makeListFin_def h1).
-    change (S (decode_Fin (code_Fin1 h1)) = S d).
-    f_equal.
-    apply decode_code1_Id.
+    - inversion i.
+    - set (d := decode_Fin i) ; assert (h1 := decode_Fin_inf_n i : d< _) ; assert (h2:= refl_equal _: d = decode_Fin i).
+      revert h1 h2 ; generalize d ; clear d ; intros [|d] h1 h2.
+      + reflexivity.
+      + assert (h3 : decode_Fin i > 0).
+        { rewrite <- h2.
+          apply lt_0_Sn. }
+        assert (i' := get_cons i h3).
+        rewrite map_length, makeListFin_nb_elem_ok in i'.
+        apply lt_S_n in h1.
+        rewrite (nth_indep _ (first n) (succ i') h1) , map_nth.
+        rewrite map_length, makeListFin_nb_elem_ok in h1.
+        rewrite <- (nth_makeListFin_def h1).
+        change (S (decode_Fin (code_Fin1 h1)) = S d).
+        f_equal.
+        apply decode_code1_Id.
   Qed.
 
   Lemma list2Fin_T_makeListFin_bis: forall (T: Set)(l: ilist T)(i: Fin (length (makeListFin (lgti l)))), 
     list2Fin_T (makeListFin (lgti l)) i = rewriteFins (makeListFin_nb_elem_ok (lgti l)) i.
   Proof.
     intros T l i.
-    destruct l as [n l] ; simpl in *|-* ; clear l.
+    destruct l as [n l] ; cbn in *|-* ; clear l.
     destruct n as [|n].
-    inversion i.
-
-    elim (zerop (decode_Fin i)) ; intros a.
-    rewrite (decode_Fin_0_first _ a).
-    simpl.
-    apply decode_Fin_unique.
-    unfold rewriteFins ; rewrite <- decode_Fin_match.
-    reflexivity.
-
-    simpl in *|-*.
-    inversion a as [H|m _ H] ;
-    [destruct n as [|n] | clear a ; revert m H;  induction n as [|n IH]; intros m H] ; 
-    try (rewrite (Fin_first_1 i) in H ; inversion H) ; 
-    apply decode_Fin_unique ; 
-    unfold rewriteFins ; rewrite <- decode_Fin_match.
-    assumption.
-    
-    destruct m as [|m].
-    assumption.
-    
-    simpl.
-    
-    rewrite (nth_indep _ (first (S n)) (succ (first n))).
-    rewrite map_nth.
-    assert (H3 : decode_Fin i >= S (S m)).
-    rewrite H.
-    apply le_refl.
-    simpl.
-    simpl in i.
-    set (i' := get_cons i  (lt_le_trans _ _ _ (lt_0_Sn (S m)) H3) : 
-      Fin (S (length (List.map (@succ (S n)) (List.map (@succ n) (makeListFin n)))))).
-    assert (H4 := decode_Fin_unique i (succ i') (decode_Fin_get_cons _ _)).
-    set (i'' := rewriteFins (eq_S _ _ 
-      (map_length (@succ (S n)) (List.map (@succ n) (makeListFin n)))) i').
-    assert (H5 : decode_Fin i'' = decode_Fin i').
-    unfold i'', rewriteFins ; apply (sym_eq (decode_Fin_match _ _ )).
-    
-    rewrite (IH i'').
-    unfold rewriteFins ; rewrite <- decode_Fin_match.
-    rewrite H5, H4.
-    reflexivity.
-
-    rewrite H5.
-    apply eq_add_S.
-    change (S (S m) = decode_Fin (succ i')).
-    rewrite <- H4.
-    assumption.
-    
-    do 2 apply lt_S_n ; rewrite H.
-    apply decode_Fin_inf_n.
+    - inversion i.
+    - elim (zerop (decode_Fin i)) ; intros a.
+      + rewrite (decode_Fin_0_first _ a).
+        simpl.
+        apply decode_Fin_unique.
+        unfold rewriteFins ; rewrite <- decode_Fin_match.
+        reflexivity.
+      + simpl in *|-*.
+        inversion a as [H|m _ H] ;
+        [destruct n as [|n] | clear a ; revert m H;  induction n as [|n IH]; intros m H] ; 
+        try (rewrite (Fin_first_1 i) in H ; inversion H) ; 
+        apply decode_Fin_unique ; 
+        unfold rewriteFins ; rewrite <- decode_Fin_match.
+        * assumption.
+        * destruct m as [|m].
+          -- assumption.
+          -- simpl.
+             rewrite (nth_indep _ (first (S n)) (succ (first n))).
+             ++ rewrite map_nth.
+                assert (H3 : decode_Fin i >= S (S m)).
+                { rewrite H.
+                  apply le_refl. }
+                simpl.
+                simpl in i.
+                set (i' := get_cons i  (lt_le_trans _ _ _ (lt_0_Sn (S m)) H3) : 
+                  Fin (S (length (List.map (@succ (S n)) (List.map (@succ n) (makeListFin n)))))).
+                assert (H4 := decode_Fin_unique i (succ i') (decode_Fin_get_cons _ _)).
+                set (i'' := rewriteFins (eq_S _ _ 
+                       (map_length (@succ (S n)) (List.map (@succ n) (makeListFin n)))) i').
+                assert (H5 : decode_Fin i'' = decode_Fin i').
+                { unfold i'', rewriteFins ; apply (sym_eq (decode_Fin_match _ _ )). }    
+                rewrite (IH i'').
+                ** unfold rewriteFins ; rewrite <- decode_Fin_match.
+                   transitivity (S(decode_Fin i')).
+                   --- f_equal.
+                       exact H5.
+                   --- cbn.
+                       rewrite H4.
+                       reflexivity.
+                ** symmetry.
+                   transitivity (decode_Fin i').
+                   --- exact H5.
+                   --- apply eq_add_S; rewrite H, H4; reflexivity.
+             ++ do 2 apply lt_S_n ; rewrite H.
+                apply decode_Fin_inf_n.
   Qed.
 
   Lemma list2ilist_app_lgti (T: Set)(t: T)(l1 l2 : list T) :
     S (lgti (list2ilist (l1 ++ l2))) = lgti (list2ilist (l1 ++ t :: l2)).
   Proof.
-    simpl.
+    cbn.
     do 2 rewrite app_length.
     apply plus_n_Sm.
   Qed.
@@ -609,11 +605,11 @@ Section ilist_def_tools.
   Proof.
     intros i.
     assert (h : lgti i = lgti (list2ilist (ilist2list i))).
-    rewrite lgti_list2ilist.
-    apply sym_eq, length_ilist2list.
+    { rewrite lgti_list2ilist.
+      apply sym_eq, length_ilist2list. }
     apply (is_ilist_rel _ _ _ h).
     intro f.
-    simpl.
+    cbn.
     unfold ilist2list.
     rewrite list2Fin_T_map_bis, list2Fin_T_makeListFin_bis.
     f_equal.
@@ -626,9 +622,9 @@ Section ilist_def_tools.
     Definition rightFin (n1 n2 : nat)(i: Fin (n1 + n2))(h: n1 <= decode_Fin i) : Fin n2.
     Proof.
       assert (h1 : decode_Fin i - n1 < n2).
-      apply (plus_lt_reg_l _ _ n1).
-      rewrite <- le_plus_minus ; try assumption.
-      apply decode_Fin_inf_n.
+      { apply (plus_lt_reg_l _ _ n1).
+        rewrite <- le_plus_minus ; try assumption.
+        apply decode_Fin_inf_n. }
       exact (code_Fin1 h1).
     Defined.
     
@@ -648,8 +644,8 @@ Section ilist_def_tools.
       apply (existT (ilistn X) (n1 + n2)).
       intro i.
       elim (le_lt_dec n1 (decode_Fin i)); intros a.
-      exact (l2 (rightFin _ _ a)).
-      exact (l1 (code_Fin1 a)).
+      - exact (l2 (rightFin _ _ a)).
+      - exact (l1 (code_Fin1 a)).
     Defined.
     
     Lemma iappend_lgti (X: Set)(l1 l2 : ilist X) : lgti (iappend l1 l2) = lgti l1 + lgti l2.
@@ -663,14 +659,14 @@ Section ilist_def_tools.
     Proof.
       destruct l1 as [n1 l1].
       destruct l2 as [n2 l2].
-      simpl in *|-*.
+      cbn in *|-*.
       unfold sumbool_rec, sumbool_rect.
       elim (le_lt_dec n1 (decode_Fin i)) ; intros a.
-      apply False_rec, (lt_irrefl n1), (le_lt_trans _ (decode_Fin i)) ; assumption.
-      f_equal.
-      apply decode_Fin_unique.
-      do 2 rewrite decode_code1_Id.
-      reflexivity.
+      - apply False_rec, (lt_irrefl n1), (le_lt_trans _ (decode_Fin i)) ; assumption.
+      - f_equal.
+        apply decode_Fin_unique.
+        do 2 rewrite decode_code1_Id.
+        reflexivity.
     Qed.
 
     Lemma iappend_right (X: Set)(l1 l2 : ilist X)(i: Fin (lgti(iappend l1 l2)))
@@ -679,19 +675,18 @@ Section ilist_def_tools.
     Proof.
       destruct l1 as [n1 l1].
       destruct l2 as [n2 l2].
-      simpl in *|-*.
+      cbn in *|-*.
       unfold sumbool_rec, sumbool_rect.
       elim (le_lt_dec n1 (decode_Fin i)) ; intros a.
-      f_equal.
-      apply decode_Fin_unique.
-      unfold rightFin ; do 2 rewrite decode_code1_Id.
-      rewrite <- decode_Fin_match'.
-      reflexivity.
-      
-      apply False_rec, (lt_irrefl n1), (le_lt_trans _ (decode_Fin i)).
-      rewrite <- decode_Fin_match' in h.
-      assumption.
-      assumption.
+      - f_equal.
+        apply decode_Fin_unique.
+        unfold rightFin ; do 2 rewrite decode_code1_Id.
+        rewrite <- decode_Fin_match'.
+        reflexivity.
+      - apply False_rec, (lt_irrefl n1), (le_lt_trans _ (decode_Fin i)).
+        + rewrite <- decode_Fin_match' in h.
+          assumption.
+        + assumption.
     Qed.
 
 
@@ -699,75 +694,68 @@ Section ilist_def_tools.
       ilist_rel eq (iappend l1 l2) (list2ilist ((ilist2list l1) ++ (ilist2list l2))).
     Proof.
       assert (h1 : lgti (iappend l1 l2) = lgti (list2ilist (ilist2list l1 ++ ilist2list l2))).
-      rewrite lgti_list2ilist, app_length, length_ilist2list, length_ilist2list.
-      apply iappend_lgti.
-      apply (is_ilist_rel _ _ _ h1).
-      
+      { rewrite lgti_list2ilist, app_length, length_ilist2list, length_ilist2list.
+        apply iappend_lgti. }
+      apply (is_ilist_rel _ _ _ h1).     
       intros i.
       rewrite <- (list2ilist_nth2 _ _ (fcti (iappend l1 l2) i)), <- decode_Fin_match'.
       elim (le_lt_dec (lgti l1) (decode_Fin i)) ; intros a.
-      assert (b := a).
-      rewrite (decode_Fin_match' i (iappend_lgti l1 l2)) in b.
-      rewrite app_nth2 ; rewrite length_ilist2list ; try assumption.
-      rewrite (iappend_right _ _ _ b).
-      unfold rightFin, eq_ind, eq_rect.
-      set (h2 := plus_lt_reg_l _ _ _ (match le_plus_minus (lgti l1)
-      (decode_Fin (rewriteFins (iappend_lgti l1 l2) i)) b in _=y return y < lgti l1 + lgti l2 with 
-      eq_refl => decode_Fin_inf_n (rewriteFins (iappend_lgti l1 l2) i) end)).
-      rewrite (decode_Fin_match' i (iappend_lgti l1 l2)).
-      apply ilist2list_nth'.
-      
-      rewrite (iappend_left _ _ _ a).
-      rewrite app_nth1.
-      apply ilist2list_nth'.
-      rewrite length_ilist2list ; assumption.
+      - assert (b := a).
+        rewrite (decode_Fin_match' i (iappend_lgti l1 l2)) in b.
+        rewrite app_nth2 ; rewrite length_ilist2list ; try assumption.
+        rewrite (iappend_right _ _ _ b).
+        unfold rightFin, eq_ind, eq_rect.
+        set (h2 := plus_lt_reg_l _ _ _ (match le_plus_minus (lgti l1)
+          (decode_Fin (rewriteFins (iappend_lgti l1 l2) i)) b in _=y return y < lgti l1 + lgti l2 with 
+          eq_refl => decode_Fin_inf_n (rewriteFins (iappend_lgti l1 l2) i) end)).
+        rewrite (decode_Fin_match' i (iappend_lgti l1 l2)).
+        apply ilist2list_nth'.
+      - rewrite (iappend_left _ _ _ a).
+        rewrite app_nth1.
+        + apply ilist2list_nth'.
+        + rewrite length_ilist2list ; assumption.
     Qed.
     
     Lemma append_iappend (T: Set)(l1 l2 : ilist T) : 
       ilist2list (iappend l1 l2) = (ilist2list l1) ++ (ilist2list l2).
     Proof.
       apply eq_nth_cor'.
-      rewrite app_length.
-      do 3 rewrite length_ilist2list.
-      apply iappend_lgti.
-      intros n d h1.
-      rewrite length_ilist2list in h1.
-      
-      rewrite <- (ilist2list_nth' _ _ h1).
-      elim (le_lt_dec (lgti l1) n) ; intros b.
-      rewrite app_nth2; rewrite length_ilist2list; try assumption.
-      
-      assert (h2 : n- lgti l1 < lgti l2).
-      rewrite <- (minus_plus (lgti l1) (lgti l2)).
-      rewrite <- iappend_lgti.
-      apply le_S_gt.
-      rewrite minus_Sn_m ; try assumption.
-      apply minus_le_compat_r.
-      apply gt_le_S.
-      assumption.
-      rewrite <- (ilist2list_nth' _ _ h2).
-      
-      assert (h3 : lgti l1 ≤ decode_Fin (rewriteFins (iappend_lgti l1 l2) (code_Fin1 h1))).
-      rewrite <- decode_Fin_match', decode_code1_Id.
-      assumption.
-      rewrite (iappend_right _ _ _ h3).
-      f_equal.
-      apply decode_Fin_unique.
-      unfold rightFin ; do 2 rewrite decode_code1_Id.
-      rewrite <- decode_Fin_match'.
-      rewrite decode_code1_Id.
-      reflexivity.
-      
-      assert (c := b) ; rewrite <- (decode_code1_Id h1) in c.
-      rewrite (iappend_left _ _ _ c).
-      rewrite app_nth1.
-      rewrite <- (ilist2list_nth' _ _ b).
-      f_equal.
-      apply decode_Fin_unique.
-      do 3 rewrite decode_code1_Id.
-      reflexivity.
-      
-      rewrite length_ilist2list; try assumption.
+      - rewrite app_length.
+        do 3 rewrite length_ilist2list.
+        apply iappend_lgti.
+      - intros n d h1.
+        rewrite length_ilist2list in h1.
+        rewrite <- (ilist2list_nth' _ _ h1).
+        elim (le_lt_dec (lgti l1) n) ; intros b.
+        + rewrite app_nth2; rewrite length_ilist2list; try assumption.
+          assert (h2 : n- lgti l1 < lgti l2).
+          * rewrite <- (minus_plus (lgti l1) (lgti l2)).
+            rewrite <- iappend_lgti.
+            apply le_S_gt.
+            rewrite minus_Sn_m ; try assumption.
+            apply minus_le_compat_r.
+            apply gt_le_S.
+            assumption.
+          * rewrite <- (ilist2list_nth' _ _ h2).
+            assert (h3 : lgti l1 ≤ decode_Fin (rewriteFins (iappend_lgti l1 l2) (code_Fin1 h1))).
+            { rewrite <- decode_Fin_match', decode_code1_Id.
+              assumption. }
+            rewrite (iappend_right _ _ _ h3).
+            f_equal.
+            apply decode_Fin_unique.
+            unfold rightFin ; do 2 rewrite decode_code1_Id.
+            rewrite <- decode_Fin_match'.
+            rewrite decode_code1_Id.
+            reflexivity.
+        + assert (c := b) ; rewrite <- (decode_code1_Id h1) in c.
+          rewrite (iappend_left _ _ _ c).
+          rewrite app_nth1.
+          * rewrite <- (ilist2list_nth' _ _ b).
+            f_equal.
+            apply decode_Fin_unique.
+            do 3 rewrite decode_code1_Id.
+            reflexivity.
+          * rewrite length_ilist2list; try assumption.
     Qed.
       
     Lemma iappend_ilist_rel (X: Set)(RelX : relation X)(ls ls' rs rs': ilist X): 
@@ -776,34 +764,34 @@ Section ilist_def_tools.
     Proof.
       intros [h1 H1] [h2 H2].
       assert (h3 : lgti (iappend ls rs) = lgti (iappend ls' rs')).
-      do 2 rewrite iappend_lgti.
-      rewrite h1, h2.
-      reflexivity.
+      { do 2 rewrite iappend_lgti.
+        rewrite h1, h2.
+        reflexivity. }
       apply (is_ilist_rel _ _ _ h3).
       intro i.
       elim (le_lt_dec (lgti ls) (decode_Fin i)) ; intros a ; assert (b := a); 
-      rewrite (decode_Fin_match' i h3), h1 in b.
-      rewrite (decode_Fin_match' i (iappend_lgti ls rs)) in a.
-      rewrite (iappend_right _ _ _ a).
-      rewrite (decode_Fin_match' _ (iappend_lgti ls' rs')) in b. 
-      rewrite (iappend_right _ _ _ b).
-      assert (H3 : rightFin (lgti rs') (rewriteFins (iappend_lgti ls' rs') (rewriteFins h3 i)) b = 
-        rewriteFins h2 (rightFin (lgti rs) (rewriteFins (iappend_lgti ls rs) i) a)).
-      apply decode_Fin_unique.
-      rewrite <- decode_Fin_match'.
-      apply (plus_reg_l _ _ (lgti ls')).
-      rewrite plus_comm, rightFin_decode_Fin, <- decode_Fin_match', <- decode_Fin_match'.
-      rewrite <- h1.
-      rewrite plus_comm, rightFin_decode_Fin, <- decode_Fin_match'.
-      reflexivity.
-      rewrite H3.
-      apply H2.
-      
-      rewrite (iappend_left _ _ _ a).
-      rewrite (iappend_left _ _ _ b).
-      assert (H3 : code_Fin1 b = rewriteFins h1 (code_Fin1 a)) by treatFinPure.
-      rewrite H3.
-      apply H1.
+        rewrite (decode_Fin_match' i h3), h1 in b.
+      - rewrite (decode_Fin_match' i (iappend_lgti ls rs)) in a.
+        rewrite (iappend_right _ _ _ a).
+        rewrite (decode_Fin_match' _ (iappend_lgti ls' rs')) in b. 
+        rewrite (iappend_right _ _ _ b).
+        assert (H3 : rightFin (lgti rs') (rewriteFins (iappend_lgti ls' rs') (rewriteFins h3 i)) b = 
+            rewriteFins h2 (rightFin (lgti rs) (rewriteFins (iappend_lgti ls rs) i) a)).
+        { apply decode_Fin_unique.
+          rewrite <- decode_Fin_match'.
+          apply (plus_reg_l _ _ (lgti ls')).
+          rewrite plus_comm, rightFin_decode_Fin, <- decode_Fin_match', <- decode_Fin_match'.
+          rewrite <- h1.
+          rewrite plus_comm, rightFin_decode_Fin, <- decode_Fin_match'.
+          reflexivity.
+        }
+        rewrite H3.
+        apply H2.
+      - rewrite (iappend_left _ _ _ a).
+        rewrite (iappend_left _ _ _ b).
+        assert (H3 : code_Fin1 b = rewriteFins h1 (code_Fin1 a)) by treatFinPure.
+        rewrite H3.
+        apply H1.
     Qed.
 
   End iappend.
@@ -818,21 +806,20 @@ Section ilist_def_tools.
   Proof.
     intros T eqT eqTRel i1 i2 ; split ; intros H ;
     destruct i1 as [n i1]; destruct i2 as [n2 i2].
-    inversion H as [e h] ; simpl in e, h.
-    assert (e' := e) ; revert i2 e H h ; rewrite <- e' ; intros i2 e H h ; clear e' n2.
-    assert (h' : forall f, eqT (i1 f) (i2 f)).
-    intro f. 
-    rewrite (decode_Fin_unique _ _ (decode_Fin_match f e) : f = rewriteFins e f) at 2 ; apply h.
-    apply ListEq_map_f_g, h'.
-
-    unfold ilist2list in H.
-    simpl in H.
-    assert (H1 := ListEq_length H).
-    do 2 (rewrite map_length, makeListFin_nb_elem_ok in H1).
-    revert i2 H ; rewrite <- H1 ; intros i2 H ; clear H1 n2.
-    apply (is_ilist_rel _ _ _ (refl_equal n : lgti (existT _ _ i1) = lgti (existT _ _ i2))) ; simpl.
-    intro f.
-    apply (ListEq_eq eqTRel _ _ _ H _ (all_Fin_n_in_makeListFin f)).
+    - inversion H as [e h] ; cbn in e, h.
+      assert (e' := e) ; revert i2 e H h ; rewrite <- e' ; intros i2 e H h ; clear e' n2.
+      assert (h' : forall f, eqT (i1 f) (i2 f)).
+      { intro f. 
+        rewrite (decode_Fin_unique _ _ (decode_Fin_match f e) : f = rewriteFins e f) at 2 ; apply h. }
+      apply ListEq_map_f_g, h'.
+    - unfold ilist2list in H.
+      cbn in H.
+      assert (H1 := ListEq_length H).
+      do 2 (rewrite map_length, makeListFin_nb_elem_ok in H1).
+      revert i2 H ; rewrite <- H1 ; intros i2 H ; clear H1 n2.
+      apply (is_ilist_rel _ _ _ (refl_equal n : lgti (existT _ _ i1) = lgti (existT _ _ i2))) ; cbn.
+      intro f.
+      apply (ListEq_eq eqTRel _ _ _ H _ (all_Fin_n_in_makeListFin f)).
   Qed.
 
   Lemma ListEq_ilist_rel_eq: 
@@ -849,12 +836,12 @@ Section ilist_def_tools.
   Proof.
     intros H1 t H2.
     induction l as [|tt l IH].
-    inversion H2.
-    inversion H1.
-    destruct H2 as [H2|H2].
-    rewrite <- H2.
-    assumption.
-    apply IH ; assumption.
+    - inversion H2.
+    - inversion H1.
+      destruct H2 as [H2|H2].
+      + rewrite <- H2.
+        assumption.
+      + apply IH ; assumption.
   Qed.
 
   Lemma ilist_rel_eq: 
@@ -862,27 +849,26 @@ Section ilist_def_tools.
   Proof.
     intros T i1 i2 ; split ; intros H ;
     destruct i1 as [n i1]; destruct i2 as [n2 i2].
-    inversion H as [e h] ; simpl in e, h.
-    assert (e' := e) ; revert i2 e H h ; rewrite <- e' ; intros i2 e H h ; clear e' n2.
-    unfold ilist2list.
-    simpl.
-    apply map_ext.
-    intro f. 
-    rewrite (decode_Fin_unique _ _ (decode_Fin_match f e) : f = rewriteFins e f) at 2 ; apply h.
-
-    unfold ilist2list in H.
-    simpl in H.
-    fold (mkilist i1) (mkilist i2).
-    assert (H1 : n = n2).
-    rewrite <- (makeListFin_nb_elem_ok n), <- (makeListFin_nb_elem_ok n2).
-    rewrite <- (map_length i1 (makeListFin n) : length (map _ _) = _), <- (map_length i2 (makeListFin n2)).
-    rewrite H.
-    reflexivity.
-    revert i2 H ; rewrite <- H1 ; intros i2 H ; clear H1 n2.
-    apply (is_ilist_rel _ _ _ (refl_equal n : lgti (mkilist i1) = lgti (mkilist i2))) ; simpl.
-    intro f.
-    apply (map_ext_in _ _ _ H).
-    apply all_Fin_n_in_makeListFin.
+    - inversion H as [e h] ; cbn in e, h.
+      assert (e' := e) ; revert i2 e H h ; rewrite <- e' ; intros i2 e H h ; clear e' n2.
+      unfold ilist2list.
+      cbn.
+      apply map_ext.
+      intro f. 
+      rewrite (decode_Fin_unique _ _ (decode_Fin_match f e) : f = rewriteFins e f) at 2 ; apply h.
+    - unfold ilist2list in H.
+      simpl in H.
+      fold (mkilist i1) (mkilist i2).
+      assert (H1 : n = n2).
+      { rewrite <- (makeListFin_nb_elem_ok n), <- (makeListFin_nb_elem_ok n2).
+        rewrite <- (map_length i1 (makeListFin n) : length (map _ _) = _), <- (map_length i2 (makeListFin n2)).
+        rewrite H.
+        reflexivity. }
+      revert i2 H ; rewrite <- H1 ; intros i2 H ; clear H1 n2.
+      apply (is_ilist_rel _ _ _ (refl_equal n : lgti (mkilist i1) = lgti (mkilist i2))) ; cbn.
+      intro f.
+      apply (map_ext_in _ _ _ H).
+      apply all_Fin_n_in_makeListFin.
   Qed.
 
 
@@ -916,44 +902,42 @@ Section ilist_def_tools.
   Proof.
     intros T U i f compT compTRel compU compURel fM.
     assert (H: lgti (imap f i) = lgti (list2ilist (map f (ilist2list i)))).
-    simpl.
-    rewrite map_length.
-    apply (sym_eq (length_ilist2list i)).
+    { cbn.
+      rewrite map_length.
+      apply (sym_eq (length_ilist2list i)). }
     apply (is_ilist_rel _ _ _ H); intro fi.
     destruct i as [ [|n] i].
-    inversion fi.
-    simpl.
-    rewrite <- (code1_decode_Id fi) at 1.
-    elim (zerop (decode_Fin (rewriteFins H fi))); intros a.
-    refine (match (sym_eq a) in (_ = df) return 
-    compU _ match df with 0 => f (i (first n)) | S m => _ end
-    with refl_equal => _ end).
-    rewrite <- (decode_Fin_match' _ H) in a.
-    rewrite code1_decode_Id, (decode_Fin_0_first _ a).
-    reflexivity.
-
-    inversion a as [e | m H1 e];
-    rewrite <- (decode_Fin_match' _ H) in e ; rewrite code1_decode_Id.
-    destruct n as [|n].
-    rewrite (Fin_first_1 fi) in e.
-    inversion e.
-    rewrite (refl_equal _: 1 = decode_Fin (succ (first n))) in e.
-    apply decode_Fin_unique in e.
-    simpl ; rewrite e; reflexivity.
-
-    assert (H2 :m < n).
-    apply (lt_S_n m n).
-    rewrite e.
-    apply decode_Fin_inf_n.
-    rewrite (map_map_nth_comp compTRel compURel i fM).
-    destruct n as [|n].
-    inversion H2.
-    rewrite (nth_indep _ (first (S n)) (succ (first n))), map_nth, <- (nth_makeListFin_def H2).
-    rewrite (decode_Fin_unique _ _ (trans_eq  (eq_S _ _ (decode_code1_Id H2) : decode_Fin (succ _) = _) e)).
-    reflexivity.
-
-    rewrite map_length, makeListFin_nb_elem_ok.
-    assumption.
+    - inversion fi.
+    - simpl.
+      rewrite <- (code1_decode_Id fi) at 1.
+      elim (zerop (decode_Fin (rewriteFins H fi))); intros a.
+      + refine (match (sym_eq a) in (_ = df) return 
+        compU _ match df with 0 => f (i (first n)) | S m => _ end
+        with refl_equal => _ end).
+        rewrite <- (decode_Fin_match' _ H) in a.
+        rewrite code1_decode_Id, (decode_Fin_0_first _ a).
+        reflexivity.
+    + inversion a as [e | m H1 e];
+        rewrite <- (decode_Fin_match' _ H) in e ; rewrite code1_decode_Id.
+      * destruct n as [|n].
+        -- rewrite (Fin_first_1 fi) in e.
+           inversion e.
+        -- rewrite (refl_equal _: 1 = decode_Fin (succ (first n))) in e.
+           apply decode_Fin_unique in e.
+           cbn ; rewrite e; reflexivity.
+      * assert (H2 :m < n).
+        { apply (lt_S_n m n).
+          rewrite e.
+          apply decode_Fin_inf_n. }
+        rewrite (map_map_nth_comp compTRel compURel i fM).
+        destruct n as [|n].
+        -- inversion H2.
+        -- rewrite (nth_indep _ (first (S n)) (succ (first n))), map_nth, <- (nth_makeListFin_def H2).
+           ++ rewrite (decode_Fin_unique _ _ (trans_eq
+                           (eq_S _ _ (decode_code1_Id H2) : decode_Fin (succ _) = _) e)).
+              reflexivity.
+           ++ rewrite map_length, makeListFin_nb_elem_ok.
+              assumption.
   Qed.
 
   Lemma list2Fin_T_succ_map_f: 
@@ -965,11 +949,11 @@ Section ilist_def_tools.
   Proof.
     intros T U l a lf f compT compU compURel fM.
     induction lf as [| hd lf IHlf].
-    apply ListEq_nil.
-    apply ListEq_cons.
-    rewrite list2Fin_T_succ.
-    reflexivity.
-    apply IHlf.
+    - apply ListEq_nil.
+    - apply ListEq_cons.
+      + rewrite list2Fin_T_succ.
+        reflexivity.
+      + apply IHlf.
   Qed.
 
   Lemma imap_cons: forall (T U: Set)(a: T)(l: list T)(f: T -> U)
@@ -981,14 +965,14 @@ Section ilist_def_tools.
   Proof.
     intros T U a l f compT compTRel compU compURel fM .
     rewrite (map_imap_ilist_list _ _ _ fM), ilist2list_list2ilist_id.
-    simpl.
+    cbn.
     apply ListEq_cons.
-    reflexivity.
-    do 2 (rewrite (map_map_ListEq compURel)).
-    unfold ilist2list, list2ilist.
-    simpl.
-    rewrite (list2Fin_T_succ_map_f l a _ compURel fM).
-    reflexivity.
+    - reflexivity.
+    - do 2 (rewrite (map_map_ListEq compURel)).
+      unfold ilist2list, list2ilist.
+      cbn.
+      rewrite (list2Fin_T_succ_map_f l a _ compURel fM).
+      reflexivity.
   Qed.
 
   Lemma imap_map_list_ilist: forall (T U: Set)(l: list T)(f: T -> U)
@@ -999,11 +983,11 @@ Section ilist_def_tools.
   Proof.
     intros T U l f compT compTRel compU compURel fM.
     induction l as [|hd l IHl].
-    reflexivity.
-    rewrite (imap_cons _ _ _ _ _).
-    apply ListEq_cons.
-    reflexivity.
-    assumption.
+    - reflexivity.
+    - rewrite (imap_cons _ _ _ _ _).
+      apply ListEq_cons.
+      + reflexivity.
+      + assumption.
   Qed.
 
    Definition ifold_left (A B : Set) (f : A → B → A) 
@@ -1041,8 +1025,8 @@ Section manip_ilist.
   Proof.
     intros T n t i f.
     inversion f as [k h |k f' h].
-    exact t.
-    exact (i f').
+    - exact t.
+    - exact (i f').
   Defined.
 
   Definition icons (T: Set)(t: T)(i: ilist T): ilist T := 
@@ -1075,22 +1059,22 @@ Section manip_ilist.
   Definition iheadOp: forall (T: Set)(i: ilist T), option T.
   Proof.
     intros T [[|n] i].
-    exact None.
-    exact (Some (i (first n))).
+    - exact None.
+    - exact (Some (i (first n))).
   Defined.
 
   Definition ihead: forall  (T: Set)(i: ilist T)(d: T), T.
   Proof.
     intros T [[|n] i] t.
-    exact t.
-    exact (i (first n)).
+    - exact t.
+    - exact (i (first n)).
   Defined.
 
   Definition itail: forall (T: Set)(i: ilist T), ilist T.
   Proof.
     intros T [[|n] i].
-    exact (inil T).
-    exact (mkilist (fun f => i (succ f))).
+    - exact (inil T).
+    - exact (mkilist (fun f => i (succ f))).
   Defined.
 
   Lemma lgti_itail: forall (T: Set)(i: ilist T), 
@@ -1104,24 +1088,25 @@ Section manip_ilist.
     lgti i >= 1 -> ilist_rel eq i (icons (ihead i d) (itail i)).
   Proof.
     intros T d [[|n] l] h.
-    inversion h.
-    fold (mkilist l) in *|-*.
-    simpl.
-    clear h.
-    assert (e := refl_equal _ : lgti (mkilist l) = 
-      lgti (icons (l (first n)) (mkilist (fun f : Fin n => l (succ f))))).
-    apply (is_ilist_rel _ _ _ e).
-    simpl.
-    intro i.
-    set (i' := rewriteFins e i) ; change (l i = iconsn (l (first n)) (fun f : Fin n => l (succ f)) i').
-    assert ( h1 : i' = i). unfold i' ; treatFinPure.
-    rewrite h1 ; clear h1.
-    elim (zerop (decode_Fin i)); intro a.
-    rewrite (decode_Fin_0_first _ a).
-    reflexivity.
-    assert (H1 : succ (get_cons i a) = i) by treatFinPure.
-    rewrite <- H1.
-    reflexivity.
+    - inversion h.
+    - fold (mkilist l) in *|-*.
+      cbn.
+      clear h.
+      assert (e := refl_equal _ : lgti (mkilist l) = 
+        lgti (icons (l (first n)) (mkilist (fun f : Fin n => l (succ f))))).
+      apply (is_ilist_rel _ _ _ e).
+      cbn.
+      intro i.
+      set (i' := rewriteFins e i) ; change (l i = iconsn (l (first n)) (fun f : Fin n => l (succ f)) i').
+      assert ( h1 : i' = i).
+      { unfold i' ; treatFinPure. }
+      rewrite h1 ; clear h1.
+      elim (zerop (decode_Fin i)); intro a.
+      + rewrite (decode_Fin_0_first _ a).
+        reflexivity.
+      + assert (H1 : succ (get_cons i a) = i) by treatFinPure.
+        rewrite <- H1.
+        reflexivity.
   Qed.
 
   Lemma itail_lgti_eq : forall (T: Set)(i1 i2: ilist T), 
@@ -1129,8 +1114,8 @@ Section manip_ilist.
   Proof.
     intros T [n1 i1] [n2 i2] e.
     destruct n1 as [|n1] ; destruct n2 as [|n2] ; try inversion e.
-    reflexivity.
-    assumption.
+    - reflexivity.
+    - assumption.
   Qed.
     
   Lemma itail_ilist_rel : forall (T: Set)(RelT : relation T)(i1 i2: ilist T), 
@@ -1140,17 +1125,17 @@ Section manip_ilist.
     apply (is_ilist_rel _ _ _ (itail_lgti_eq _ _ e)).
     intro f.
     destruct i1 as [[|n1] i1].
-    inversion f.
-    destruct i2 as [[|n2] i2].
-    inversion e.
-    simpl in e, H, f.
-    simpl.
-    assert (h: succ (rewriteFins (itail_lgti_eq (mkilist i1)
-      (mkilist i2) e) f) = (rewriteFins e (succ f))).
-    treatFinPure.
-    assert (H':= H (succ f)).
-    rewrite <- h in H'.
-    assumption.
+    - inversion f.
+    - destruct i2 as [[|n2] i2].
+      + inversion e.
+      + cbn in e, H, f.
+        cbn.
+        assert (h: succ (rewriteFins (itail_lgti_eq (mkilist i1)
+          (mkilist i2) e) f) = (rewriteFins e (succ f))).
+        { treatFinPure. }
+        assert (H':= H (succ f)).
+        rewrite <- h in H'.
+        assumption.
   Qed.
 
   Lemma imap_ilist_rel(T U: Set)(RelT: relation T)(RelU : relation U)(RelUEq: Equivalence RelU)(f: T -> U)
@@ -1161,11 +1146,11 @@ Section manip_ilist.
     assert (h' := h).
     rewrite <- (imap_lgti l1 f), <- (imap_lgti l2 f) in h'.
     apply (is_ilist_rel _ _ _ h').
-    simpl.
+    cbn.
     intro i.
     rewrite (H i).
     assert (Hi: rewriteFins h i = rewriteFins h' i).
-    apply decode_Fin_unique ; unfold rewriteFins ; do 2 rewrite <- decode_Fin_match ; reflexivity.
+    { apply decode_Fin_unique ; unfold rewriteFins ; do 2 rewrite <- decode_Fin_match ; reflexivity. }
     rewrite Hi.
     reflexivity.
   Qed.
@@ -1175,18 +1160,18 @@ Section manip_ilist.
    Proof.
      assert (h:= refl_equal _: lgti (imap f (icons t l))  = lgti (icons (f t) (imap f l))).
      apply (is_ilist_rel _ _ _ h).
-     simpl.
+     cbn.
      intro i.
      destruct l as [n l].
-     simpl in *|-*.
+     cbn in *|-*.
      assert (h1 : rewriteFins h i = i) by treatFinPure.
      rewrite h1 ; clear h h1.
      elim (zerop (decode_Fin i)) ; intros a.
-     rewrite (decode_Fin_0_first _ a).
-     reflexivity.
-     assert (h1 : i = succ (get_cons i a)) by treatFinPure.
-     rewrite h1 ; clear h1.
-     reflexivity.
+     - rewrite (decode_Fin_0_first _ a).
+       reflexivity.
+     - assert (h1 : i = succ (get_cons i a)) by treatFinPure.
+       rewrite h1 ; clear h1.
+       reflexivity.
    Qed.
 
   Lemma inil_nil (T: Set)(RelT : relation T) : ilist_rel eq (inil T) (list2ilist nil).
@@ -1204,45 +1189,45 @@ Section manip_ilist.
   Lemma icons_cons (T: Set)(t: T)(l: ilist T) : ilist_rel eq (icons t l) (list2ilist (t :: (ilist2list l))).
   Proof.
     assert (h : lgti (icons t l) = lgti (list2ilist (t :: ilist2list l))).
-    simpl.
-    rewrite length_ilist2list.
-    reflexivity.
+    { cbn.
+      rewrite length_ilist2list.
+      reflexivity. }
     apply (is_ilist_rel _ _ _ h).
-    simpl.
+    cbn.
     intro i.
     rewrite <- decode_Fin_match'.
     elim (zerop (decode_Fin i)) ; intro a.
-    rewrite a, (decode_Fin_0_first _ a).
-    reflexivity.
-    rewrite (decode_Fin_unique _ _ (decode_Fin_get_cons _ a : _ = decode_Fin (succ _))).
-    simpl.
-    rewrite (nth_indep _ _ (fcti l (get_cons i a))).
-    apply ilist2list_nth2.
-    rewrite length_ilist2list.
-    apply decode_Fin_inf_n.
+    - rewrite a, (decode_Fin_0_first _ a).
+      reflexivity.
+    - rewrite (decode_Fin_unique _ _ (decode_Fin_get_cons _ a : _ = decode_Fin (succ _))).
+      cbn.
+      rewrite (nth_indep _ _ (fcti l (get_cons i a))).
+      + apply ilist2list_nth2.
+      + rewrite length_ilist2list.
+        apply decode_Fin_inf_n.
   Qed.
     
   Lemma cons_icons (T: Set)(t: T)(l: list T) : 
     ilist2list (icons t (list2ilist l)) = t :: l.
   Proof.
     unfold ilist2list.
-    simpl.
+    cbn.
     f_equal.
     rewrite map_map.
-    simpl.
+    cbn.
     clear t.
     destruct l as [|t l].
-    reflexivity.
-    simpl.
+    { reflexivity. }
+    cbn.
     f_equal.
     rewrite map_map.
-    simpl.
+    cbn.
     induction l as [|t' l IH].
-    reflexivity.
-    simpl.
+    { reflexivity. }
+    cbn.
     f_equal.
     rewrite map_map.
-    simpl.
+    cbn.
     apply IH.
   Qed.
 
@@ -1251,7 +1236,7 @@ Section manip_ilist.
     ilist2list (icons t l) = t :: (ilist2list l).
   Proof.
     unfold ilist2list.
-    simpl.
+    cbn.
     rewrite map_map.
     reflexivity.
   Qed.
@@ -1262,25 +1247,25 @@ Section manip_ilist.
   Proof.
     intros H1 [h H2] H3.
     apply iappend_ilist_rel.
-    apply H1.
-    assert (h' : lgti (icons x rs) = lgti (icons x' rs')).
-    simpl.
-    f_equal; assumption.
-    apply (is_ilist_rel _ _ _ h').
-    intro i.
-    elim (zerop (decode_Fin i)) ; intros a.
-    rewrite (decode_Fin_0_first _ a).
-    assert (H4 : rewriteFins h' (first (lgti rs)) = first (lgti rs')) by treatFinPure.
-    rewrite H4.
-    assumption.
-    rewrite <- (get_cons_ok1 _ a).
-    assert (H4 : rewriteFins h' (succ (get_cons i a)) = succ (rewriteFins h (get_cons i a))).
-    apply decode_Fin_unique.
-    simpl.
-    do 2 rewrite <- decode_Fin_match'.
-    reflexivity.
-    rewrite H4.
-    apply H2.
+    - apply H1.
+    - assert (h' : lgti (icons x rs) = lgti (icons x' rs')).
+      { cbn.
+        f_equal; assumption. }
+      apply (is_ilist_rel _ _ _ h').
+      intro i.
+      elim (zerop (decode_Fin i)) ; intros a.
+      + rewrite (decode_Fin_0_first _ a).
+        assert (H4 : rewriteFins h' (first (lgti rs)) = first (lgti rs')) by treatFinPure.
+        rewrite H4.
+        assumption.
+      + rewrite <- (get_cons_ok1 _ a).
+        assert (H4 : rewriteFins h' (succ (get_cons i a)) = succ (rewriteFins h (get_cons i a))).
+        { apply decode_Fin_unique.
+          cbn.
+          do 2 rewrite <- decode_Fin_match'.
+          reflexivity. }
+        rewrite H4.
+        apply H2.
   Qed.
   
 End manip_ilist.
@@ -1310,8 +1295,8 @@ Qed.
       apply (@mkilist X (lgti l - (S (decode_Fin i)))).
       intro i'.
       assert (h : S (decode_Fin i) + decode_Fin i' < lgti l).
-      rewrite (le_plus_minus _ (lgti l) (gt_le_S _ _ (decode_Fin_inf_n i))).
-      apply (plus_gt_compat_l _ _ (S (decode_Fin i))), decode_Fin_inf_n.
+      { rewrite (le_plus_minus _ (lgti l) (gt_le_S _ _ (decode_Fin_inf_n i))).
+        apply (plus_gt_compat_l _ _ (S (decode_Fin i))), decode_Fin_inf_n. }
       exact (fcti l (code_Fin1 h)).
     Defined.
     
@@ -1324,7 +1309,7 @@ Qed.
     Lemma left_sib_right_sib_lgti (X: Set)(l: ilist X)(i: Fin (lgti l)) : 
       S (lgti (left_sib l i) + lgti (right_sib l i)) = lgti l.
     Proof.
-      simpl.
+      cbn.
       rewrite <- plus_Sn_m.
       apply sym_eq, (le_plus_minus _ _ (gt_le_S _ _ (decode_Fin_inf_n i))).
     Qed.
@@ -1333,60 +1318,55 @@ Qed.
       ilist2list (left_sib l i) ++ (fcti l i) :: ilist2list (right_sib l i) = ilist2list l.
     Proof.
       apply eq_nth_cor'.
-      rewrite app_length.
-      simpl.
-      repeat rewrite length_ilist2list.
-      rewrite <- plus_n_Sm.
-      apply left_sib_right_sib_lgti.
-      
-      intros n d h .
-      rewrite app_length in h ; simpl in h ; rewrite <- plus_n_Sm, <- plus_Sn_m in h.
-      do 2 rewrite length_ilist2list in h.
-      assert (a : n < lgti l).
-      rewrite <- (left_sib_right_sib_lgti l i) ; assumption.
-      clear h.
-      rewrite <- (ilist2list_nth' _ _ a).
-      
-      elim (le_lt_dec (decode_Fin i) n) ; intros b.
-      rewrite app_nth2 ;
-      rewrite length_ilist2list, left_sib_lgti ; try assumption.
-      simpl.
-      set (x := n - decode_Fin i).
-      assert (h1 := refl_equal _ : n - decode_Fin i = x).
-      destruct x as [|x].
-      f_equal.
-      apply decode_Fin_unique.
-      rewrite decode_code1_Id.
-      apply sym_eq, (minus_n_m_0 b h1).
-      
-      assert (h2 : x < lgti (right_sib l i)).
-      apply lt_S_n.
-      rewrite <- h1.
-      rewrite right_sib_lgti.
-      rewrite minus_Sn_m, Sn_Sm_eq_n_m.
-      apply le_S_gt.
-      rewrite minus_Sn_m; try assumption.
-      apply minus_le_compat_r.
-      apply gt_le_S, a.
-      apply gt_le_S, decode_Fin_inf_n.
-      
-      rewrite <- (ilist2list_nth' _ _ h2).
-      simpl.
-      f_equal.
-      apply decode_Fin_unique.
-      repeat rewrite decode_code1_Id.
-      rewrite plus_n_Sm, <-h1.
-      apply sym_eq, le_plus_minus ; assumption.
-      
-      rewrite app_nth1.
-      assert (h1 : n < lgti (left_sib l i)).
-      rewrite left_sib_lgti; assumption.
-      
-      rewrite <- (ilist2list_nth' _ _ h1).
-      simpl.
-      f_equal.
-      treatFinPure.
-      rewrite length_ilist2list ; assumption.
+      - rewrite app_length.
+        simpl.
+        repeat rewrite length_ilist2list.
+        rewrite <- plus_n_Sm.
+        apply left_sib_right_sib_lgti.
+      - intros n d h .
+        rewrite app_length in h ; simpl in h ; rewrite <- plus_n_Sm, <- plus_Sn_m in h.
+        do 2 rewrite length_ilist2list in h.
+        assert (a : n < lgti l).
+        { rewrite <- (left_sib_right_sib_lgti l i) ; assumption. }
+        clear h.
+        rewrite <- (ilist2list_nth' _ _ a).
+        elim (le_lt_dec (decode_Fin i) n) ; intros b.
+        + rewrite app_nth2 ;
+            rewrite length_ilist2list, left_sib_lgti ; try assumption.
+          cbn.
+          set (x := n - decode_Fin i).
+          assert (h1 := refl_equal _ : n - decode_Fin i = x).
+          destruct x as [|x].
+          * f_equal.
+            apply decode_Fin_unique.
+            rewrite decode_code1_Id.
+            apply sym_eq, (minus_n_m_0 b h1).
+          * assert (h2 : x < lgti (right_sib l i)).
+            { apply lt_S_n.
+              rewrite <- h1.
+              rewrite right_sib_lgti.
+              rewrite minus_Sn_m, Sn_Sm_eq_n_m.
+              - apply le_S_gt.
+                rewrite minus_Sn_m; try assumption.
+                apply minus_le_compat_r.
+                apply gt_le_S, a.
+              - apply gt_le_S, decode_Fin_inf_n.
+            }
+            rewrite <- (ilist2list_nth' _ _ h2).
+            cbn.
+            f_equal.
+            apply decode_Fin_unique.
+            repeat rewrite decode_code1_Id.
+            rewrite plus_n_Sm, <-h1.
+            apply sym_eq, le_plus_minus ; assumption.
+        + rewrite app_nth1.
+          * assert (h1 : n < lgti (left_sib l i)).
+            { rewrite left_sib_lgti; assumption. }      
+            rewrite <- (ilist2list_nth' _ _ h1).
+            cbn.
+            f_equal.
+            treatFinPure.
+          * rewrite length_ilist2list ; assumption.
     Qed.
 
     Lemma left_sib_right_sib_cor (T: Set)(l: ilist T)(i: Fin (lgti (l))) : 
@@ -1403,61 +1383,61 @@ Qed.
     Proof.
       intros X RelX Rrefl l i.
       assert (h : lgti l = lgti (iappend (left_sib l i) (icons (fcti l i) (right_sib l i)))).
-      rewrite iappend_lgti.
-      change (lgti (icons (fcti l i) (right_sib l i))) with (S (lgti (right_sib l i))).
-      rewrite <- plus_n_Sm.
-      rewrite left_sib_right_sib_lgti.
-      reflexivity.
+      { rewrite iappend_lgti.
+        change (lgti (icons (fcti l i) (right_sib l i))) with (S (lgti (right_sib l i))).
+        rewrite <- plus_n_Sm.
+        rewrite left_sib_right_sib_lgti.
+        reflexivity. }
       apply (is_ilist_rel _ _ _ h).
       intro i'.
       elim (le_lt_dec (lgti (left_sib l i)) (decode_Fin i') ) ; intros a.
-      rewrite (decode_Fin_match' i' h), (decode_Fin_match' _   (iappend_lgti _ _)) in a.
-      rewrite (iappend_right _ _ _ a).
-      set (i1 := rightFin (lgti (icons (fcti l i) (right_sib l i))) (rewriteFins
-        (iappend_lgti (left_sib l i) (icons (fcti l i) (right_sib l i))) (rewriteFins h i')) a).
-      elim (zerop (decode_Fin i1)) ; intros b.
-      rewrite (decode_Fin_0_first _ b).
-      simpl.
-      assert (i = i').
-      apply decode_Fin_unique.
-      simpl in a.
-      assert (H1 := rightFin_decode_Fin _ _ a).
-      do 2 rewrite <- decode_Fin_match' in H1.
-      rewrite <- H1.
-      change (decode_Fin i = decode_Fin i1 + decode_Fin i).
-      rewrite b.
-      symmetry.
-      apply plus_O_n.
-      rewrite H.
-      apply Rrefl.
-      
-      rewrite <- (get_cons_ok1 _ b).
-      change (RelX (fcti l i') (fcti (right_sib l i) (get_cons i1 b))).
-      simpl.
-      assert (i' = (code_Fin1 (eq_ind_r (lt _) (plus_gt_compat_l _ _ _ (decode_Fin_inf_n (get_cons _ b)))
+      - rewrite (decode_Fin_match' i' h), (decode_Fin_match' _   (iappend_lgti _ _)) in a.
+        rewrite (iappend_right _ _ _ a).
+        set (i1 := rightFin (lgti (icons (fcti l i) (right_sib l i))) (rewriteFins
+          (iappend_lgti (left_sib l i) (icons (fcti l i) (right_sib l i))) (rewriteFins h i')) a).
+        elim (zerop (decode_Fin i1)) ; intros b.
+        + rewrite (decode_Fin_0_first _ b).
+          cbn.
+          assert (i = i').
+          { apply decode_Fin_unique.
+            cbn in a.
+            assert (H1 := rightFin_decode_Fin _ _ a).
+            do 2 rewrite <- decode_Fin_match' in H1.
+            rewrite <- H1.
+            change (decode_Fin i = decode_Fin i1 + decode_Fin i).
+            rewrite b.
+            symmetry.
+            apply plus_O_n.
+          }
+          rewrite H.
+          apply Rrefl.
+      + rewrite <- (get_cons_ok1 _ b).
+        change (RelX (fcti l i') (fcti (right_sib l i) (get_cons i1 b))).
+        simpl.
+        assert (i' = (code_Fin1 (eq_ind_r (lt _) (plus_gt_compat_l _ _ _ (decode_Fin_inf_n (get_cons _ b)))
            (le_plus_minus _ _ (gt_le_S _ _ (decode_Fin_inf_n i)))))).
-      apply decode_Fin_unique.
-      rewrite decode_code1_Id.
-      rewrite plus_Sn_m, plus_n_Sm.
-      rewrite <- decode_Fin_get_cons.
-      change (decode_Fin i) with (lgti (left_sib l i)).
-      unfold i1.
-      rewrite plus_comm.
-      rewrite rightFin_decode_Fin.
-      do 2 rewrite <- decode_Fin_match'.
-      reflexivity.
-      rewrite H.
-      apply Rrefl.
-
-      rewrite (decode_Fin_match' i' h) in a.
-      rewrite (iappend_left _ _ _ a).
-      simpl.
-      assert (code_Fin1 (lt_trans _ _ _ (decode_Fin_inf_n (code_Fin1 a)) (decode_Fin_inf_n i)) = i').
-      apply decode_Fin_unique.
-      do 2 rewrite decode_code1_Id.
-      apply sym_eq, decode_Fin_match'.
-      rewrite <- H at 1.
-      apply Rrefl.
+        { apply decode_Fin_unique.
+          rewrite decode_code1_Id.
+          rewrite plus_Sn_m, plus_n_Sm.
+          rewrite <- decode_Fin_get_cons.
+          change (decode_Fin i) with (lgti (left_sib l i)).
+          unfold i1.
+          rewrite plus_comm.
+          rewrite rightFin_decode_Fin.
+          do 2 rewrite <- decode_Fin_match'.
+          reflexivity.
+        }
+        rewrite H.
+        apply Rrefl.
+      - rewrite (decode_Fin_match' i' h) in a.
+        rewrite (iappend_left _ _ _ a).
+        cbn.
+        assert (H: code_Fin1 (lt_trans _ _ _ (decode_Fin_inf_n (code_Fin1 a)) (decode_Fin_inf_n i)) = i').
+        { apply decode_Fin_unique.
+          do 2 rewrite decode_code1_Id.
+          apply sym_eq, decode_Fin_match'. }
+        rewrite <- H at 1.
+        apply Rrefl.
     Qed.
 
     Lemma left_sib_ilist_rel (X: Set)(RelX : relation X)(xs xs': ilist X)(i: Fin (lgti xs))(h: lgti xs = lgti xs'): 
@@ -1465,14 +1445,14 @@ Qed.
     Proof.
       intros [h1 H1].
       assert (h2 : lgti (left_sib xs i) = lgti (left_sib xs' (rewriteFins h i))).
-      apply decode_Fin_match'.
+      { apply decode_Fin_match'. }
       apply (is_ilist_rel _ _ _ h2).
       intro i'.
-      simpl.
+      cbn.
       assert (H2 : code_Fin1 (lt_trans _ _ _ (decode_Fin_inf_n (rewriteFins h2 i')) 
         (decode_Fin_inf_n (rewriteFins h i))) = rewriteFins h1 (code_Fin1
         (lt_trans _ _ _ (decode_Fin_inf_n i') (decode_Fin_inf_n i)))) by treatFinPure.
-      simpl in H2.
+      cbn in H2.
       rewrite H2.
       apply H1.
     Qed.
@@ -1482,22 +1462,22 @@ Qed.
     Proof.
       intros [h1 H1].
       assert (h2 : lgti (right_sib xs i) = lgti (right_sib xs' (rewriteFins h i))).
-      simpl.
-      rewrite <- decode_Fin_match', <- h1.
-      reflexivity.
+      { cbn.
+        rewrite <- decode_Fin_match', <- h1.
+        reflexivity. }
       apply (is_ilist_rel _ _ _ h2).
       intro i'.
-      simpl.
+      cbn.
       set (i1 := code_Fin1 (eq_ind_r (lt _) (plus_gt_compat_l _ _ _ (decode_Fin_inf_n i'))
            (le_plus_minus _ _ (gt_le_S _ _ (decode_Fin_inf_n i))))).
-      assert (code_Fin1 (eq_ind_r (lt _) (plus_gt_compat_l _ _ _ (decode_Fin_inf_n (rewriteFins h2 i')))
+      assert (H: code_Fin1 (eq_ind_r (lt _) (plus_gt_compat_l _ _ _ (decode_Fin_inf_n (rewriteFins h2 i')))
            (le_plus_minus _ _  (gt_le_S _ _  (decode_Fin_inf_n (rewriteFins h i))))) = rewriteFins h1 i1).
-      apply decode_Fin_unique.
-      unfold i1.
-      rewrite decode_code1_Id.
-      do 3 rewrite <- decode_Fin_match'.
-      rewrite decode_code1_Id.
-      apply plus_Sn_m.
+      { apply decode_Fin_unique.
+        unfold i1.
+        rewrite decode_code1_Id.
+        do 3 rewrite <- decode_Fin_match'.
+        rewrite decode_code1_Id.
+        apply plus_Sn_m. }
       assert (H1' := H1 i1).
       rewrite <- H in H1'.
       assumption.
@@ -1509,16 +1489,16 @@ Qed.
     Proof.
       intros H1.
       assert (h1 : lgti l1 = lgti (left_sib (iappend l1 (icons t l2)) (code_Fin1 h))).
-      simpl.
-      rewrite decode_code1_Id.
-      symmetry ; assumption.
+      { cbn.
+        rewrite decode_code1_Id.
+        symmetry ; assumption. }
       apply (is_ilist_rel _ _ _ h1).
       intro i.
-      simpl.
+      cbn.
       assert (h2 : decode_Fin ((code_Fin1 (lt_trans _ _ _
         (decode_Fin_inf_n (rewriteFins h1 i)) (decode_Fin_inf_n (code_Fin1 h))))) < lgti l1).
-      rewrite decode_code1_Id, <- decode_Fin_match'.
-      apply decode_Fin_inf_n.
+      { rewrite decode_code1_Id, <- decode_Fin_match'.
+        apply decode_Fin_inf_n. }
       assert (H3 : i = code_Fin1 h2) by treatFinPure.
       rewrite H3 at 1.
       symmetry.
@@ -1531,32 +1511,32 @@ Qed.
     Proof.
       intros H1.
       assert (h1 : lgti l2 = lgti (right_sib (iappend l1 (icons t l2)) (code_Fin1 h))).
-      simpl.
-      rewrite decode_code1_Id.
-      rewrite iappend_lgti.
-      simpl.
-      rewrite <- plus_n_Sm, <- plus_Sn_m.
-      rewrite H1.
-      apply sym_eq, minus_plus.
+      { cbn.
+        rewrite decode_code1_Id.
+        rewrite iappend_lgti.
+        cbn.
+        rewrite <- plus_n_Sm, <- plus_Sn_m.
+        rewrite H1.
+        apply sym_eq, minus_plus. }
       apply (is_ilist_rel _ _ _ h1).
       intro i.
-      simpl.
+      cbn.
       assert (h2 : lgti l1 <= decode_Fin (rewriteFins (iappend_lgti l1 _)
         (code_Fin1 (eq_ind_r (lt _) (plus_gt_compat_l _ _ _ (decode_Fin_inf_n (rewriteFins h1 i)))
         (le_plus_minus _ _ (gt_le_S _ _  (decode_Fin_inf_n (code_Fin1 h)))))))).
-      do 2 (rewrite <- decode_Fin_match', decode_code1_Id).
-      rewrite H1.
-      rewrite plus_Sn_m, plus_n_Sm.
-      apply le_plus_l.
+      { do 2 (rewrite <- decode_Fin_match', decode_code1_Id).
+        rewrite H1.
+        rewrite plus_Sn_m, plus_n_Sm.
+        apply le_plus_l. }
       assert (H3 := iappend_right _ _ _ h2).
       assert (H4 : rightFin _ (rewriteFins (iappend_lgti l1 (icons t l2))
              (code_Fin1 (eq_ind_r  (lt _) (plus_gt_compat_l _ _ _ (decode_Fin_inf_n (rewriteFins h1 i)))
              (le_plus_minus _ _ (gt_le_S _ _ (decode_Fin_inf_n (code_Fin1 h))))))) h2 = succ i).
-      apply decode_Fin_unique.
-      apply (plus_reg_l _ _ (lgti l1)).
-      rewrite plus_comm.
-      rewrite rightFin_decode_Fin, <- decode_Fin_match', decode_code1_Id, decode_code1_Id, <- decode_Fin_match', H1.
-      apply plus_n_Sm.
+      { apply decode_Fin_unique.
+        apply (plus_reg_l _ _ (lgti l1)).
+        rewrite plus_comm.
+        rewrite rightFin_decode_Fin, <- decode_Fin_match', decode_code1_Id, decode_code1_Id, <- decode_Fin_match', H1.
+        apply plus_n_Sm. }
       rewrite H4 in H3.
       clear H4.
       change (fcti (icons t l2) (succ i)) with (fcti l2 i) in H3.
@@ -1568,15 +1548,15 @@ Qed.
     Proof.
       intros H.
       assert (h1 : lgti l1 <= decode_Fin (rewriteFins (iappend_lgti l1 (icons t l2)) (code_Fin1 h))).
-      rewrite <- decode_Fin_match', decode_code1_Id.
-      rewrite H ; apply le_refl.
+      { rewrite <- decode_Fin_match', decode_code1_Id.
+        rewrite H ; apply le_refl. }
       rewrite (iappend_right _ _ _ h1).
       assert (H2 : 
         rightFin (lgti (icons t l2)) (rewriteFins (iappend_lgti l1 (icons t l2)) (code_Fin1 h)) h1 = first _).
-      apply decode_Fin_unique, (plus_reg_l _ _ (lgti l1)).
-      rewrite plus_comm.
-      rewrite rightFin_decode_Fin, <- decode_Fin_match', decode_code1_Id, H.
-      apply plus_n_O.
+      { apply decode_Fin_unique, (plus_reg_l _ _ (lgti l1)).
+        rewrite plus_comm.
+        rewrite rightFin_decode_Fin, <- decode_Fin_match', decode_code1_Id, H.
+        apply plus_n_O. }
       rewrite H2.
       reflexivity.
     Qed.
@@ -1589,39 +1569,40 @@ Qed.
     Proof.
       destruct l as [n l].
       induction n as [|n IH].
-      exact nil.
-      exact (l (first n) ++ (IH (fun i => l (succ i)))).
+      - exact nil.
+      - exact (l (first n) ++ (IH (fun i => l (succ i)))).
     Defined.
     
     Lemma ilflatten_mkilist (X: Set)(n: nat)(l: ilistn (list X) n)(i: Fin n): incl (l i) (ilflatten (mkilist l)).
     Proof.
       induction n as [|n IH].
-      inversion i.
-      elim (zerop (decode_Fin i)) ; intros a.
-      rewrite (decode_Fin_0_first _ a).
-      apply incl_appl.
-      apply incl_refl.
-      rewrite <- (get_cons_ok1 _ a).
-      apply incl_appr.
-      change (incl ((fun x => l (succ x)) (get_cons i a)) (ilflatten (mkilist (fun x => l (succ x))))).
-      apply IH.
+      - inversion i.
+      - elim (zerop (decode_Fin i)) ; intros a.
+        + rewrite (decode_Fin_0_first _ a).
+          apply incl_appl.
+          apply incl_refl.
+        + rewrite <- (get_cons_ok1 _ a).
+          apply incl_appr.
+          change (incl ((fun x => l (succ x)) (get_cons i a)) (ilflatten (mkilist (fun x => l (succ x))))).
+          apply IH.
     Qed.
     
     Lemma ilflatten_ilist_rel(X: Set)(l l': ilist (list X)): ilist_rel eq l l' -> ilflatten l = ilflatten l'.
     Proof.
       intros [h H].
       destruct l as [n l] ; destruct l' as [n' l'].
-      simpl in h.
+      cbn in h.
       revert l' H ; rewrite <- h ; clear n' h  ; intros l' H.
-      simpl in H.
+      cbn in H.
       induction n as [|n IH].
-      reflexivity.
-      simpl.
-      rewrite H.
-      f_equal.
-      apply IH.
-      intro i ; apply H.
+      - reflexivity.
+      - cbn.
+        rewrite H.
+        f_equal.
+        apply IH.
+        intro i ; apply H.
     Qed.
+    
   End ilflatten.
    
   Section ilist_rel_dec.
@@ -1646,49 +1627,48 @@ Qed.
     Proof.
       intros [n1 l1] [n2 l2].
       elim (eq_nat_dec n1 n2) ; intros H.
-      revert l2.
-      rewrite <- H.
-      intros l2 ; clear n2 H.
-      fold (mkilist l1) (mkilist l2) in *|-*.
-      induction n1 as [|n1 IH].
-      left.
-      apply (ilist_rel_mon (@eq_subrelation _ RelT _)).
-      apply ilist_rel_nil.
-      destruct (Rdec (l1 (first n1)) (l2 (first n1))) as [H1 | H1].
-      destruct (IH (fun x => l1 (succ x)) (fun x => l2 (succ x))) as [H2 | H2].
-      left.
-      apply (is_ilist_rel  _ _ _ (refl_equal _: lgti (mkilist l1) = lgti (mkilist l2))).
-      simpl.
-      intro i.
-      elim (zerop (decode_Fin i)) ; intros H3.
-      rewrite (decode_Fin_0_first _ H3) in *|-* ; clear i H3.
-      assumption.
-      destruct H2 as [H2 H4].
-      simpl in *|-*.
-      assert (H5 := H4 (get_cons _ H3)).
-      assert (H6 : rewriteFins H2 (get_cons i H3) = get_cons i H3) by treatFinPure.
-      rewrite H6 in H5 ; clear H2 H4 H6.
-      rewrite (decode_Fin_unique _ _(decode_Fin_get_cons _ _ : decode_Fin i = decode_Fin (succ (get_cons i H3)))).
-      assumption.
-      
-      right.
-      intros [H3 H4] ; apply H2.
-      apply (is_ilist_rel  _ _ _ (refl_equal _: 
-      lgti (mkilist (fun x => l1 (succ x))) = lgti (mkilist (fun x => l2 (succ x))))).
-      simpl in *|-*.
-      intro i ; rewrite (H4 (succ i)).
-      apply fRel ; try assumption.
-      treatFinPure.
-      
-      right.
-      intros [H2 H3] ; apply H1.
-      rewrite (H3 (first n1)).
-      apply fRel ; try assumption.
-      treatFinPure.
-      
-      right.
-      intros [H1 _].
-      contradiction.
+      - revert l2.
+        rewrite <- H.
+        intros l2 ; clear n2 H.
+        fold (mkilist l1) (mkilist l2) in *|-*.
+        induction n1 as [|n1 IH].
+        + left.
+          apply (ilist_rel_mon (@eq_subrelation _ RelT _)).
+          apply ilist_rel_nil.
+        + destruct (Rdec (l1 (first n1)) (l2 (first n1))) as [H1 | H1].
+          * destruct (IH (fun x => l1 (succ x)) (fun x => l2 (succ x))) as [H2 | H2].
+            -- left.
+               apply (is_ilist_rel  _ _ _ (refl_equal _: lgti (mkilist l1) = lgti (mkilist l2))).
+               cbn.
+               intro i.
+               elim (zerop (decode_Fin i)) ; intros H3.
+               ++ rewrite (decode_Fin_0_first _ H3) in *|-* ; clear i H3.
+                  assumption.
+               ++ destruct H2 as [H2 H4].
+                  cbn in *|-*.
+                  assert (H5 := H4 (get_cons _ H3)).
+                  assert (H6 : rewriteFins H2 (get_cons i H3) = get_cons i H3) by treatFinPure.
+                  rewrite H6 in H5 ; clear H2 H4 H6.
+                  rewrite (decode_Fin_unique _ _(decode_Fin_get_cons _ _ : decode_Fin i = decode_Fin (succ (get_cons i H3)))).
+                  assumption.
+            -- right.
+               intros [H3 H4] ; apply H2.
+               apply (is_ilist_rel  _ _ _ (refl_equal _: 
+                  lgti (mkilist (fun x => l1 (succ x))) = lgti (mkilist (fun x => l2 (succ x))))).
+               cbn in *|-*.
+               intro i ; rewrite (H4 (succ i)).
+               apply fRel ; try assumption.
+               treatFinPure.
+          * right.
+            intros [H2 H3] ; apply H1.
+            rewrite (H3 (first n1)).
+            apply fRel ; try assumption.
+            treatFinPure.
+      - right.
+        intros [H1 _].
+        contradiction.
     Qed.
-  End ilist_rel_dec.  
+    
+  End ilist_rel_dec.
+  
 End ilist_def_tools.

--- a/IlistMult.v
+++ b/IlistMult.v
@@ -161,7 +161,7 @@ Section ilistMult_def_tools.
       apply (is_imeq cmp l1 l3 (trans_eq e1 e2)).
       intros f.
       assert (H1: rewriteFins (eq_trans e1 e2) f = rewriteFins e2 (rewriteFins e1 f)).
-      treatFinPure.
+      { treatFinPure. }
       rewrite H1.
       apply (cmp_trans _ _ _ (h1 f) (h2 _)).
     Qed.
@@ -305,8 +305,8 @@ Section Bij_ilistMult_list.
   Proof.
     intros t i f.
     assert (H: decode_Fin f < length (ilistM2list i)).
-    rewrite length_ilistM2list.
-    apply decode_Fin_inf_n.
+    { rewrite length_ilistM2list.
+      apply decode_Fin_inf_n. }
     rewrite (nth_indep (ilistM2list i) t (ffctiMult i f) H).
     apply ilistM2list_nth2.
   Qed.
@@ -336,30 +336,30 @@ Section Bij_ilistMult_list.
     intro f.
     elim (zerop (decode_Fin f)) ; intros a ;
     destruct l as [| h l].
-    inversion f.
-    left.
-    refine (match (sym_eq a) in (_ = df) return 
-      h = match df with 0 => h | S m => nth m l h end 
-      with refl_equal => _ end).
-    reflexivity.
-    inversion f.
-    right.
-    inversion a as [e | n H e].
-    refine (match e in (_ = df) return 
-      In match df with 0 => h | S m => nth m l h end l 
-      with refl_equal => _ end).
-    destruct l as [| ht l].
-    apply 
-      (lt_irrefl _ (gt_le_trans _ _ _ a (gt_S_le _ _ (decode_Fin_inf_n f)))).
-    left ; reflexivity.
-    refine (match e in (_ = df) return 
-      In match df with 0 => h | S m => nth m l h end l 
-      with refl_equal => _ end).
-    assert (H': n < (length l)).
-    apply lt_S_n.
-    rewrite e.
-    apply decode_Fin_inf_n.
-    apply (nth_In _ _ H').
+    - inversion f.
+    - left.
+      refine (match (sym_eq a) in (_ = df) return 
+        h = match df with 0 => h | S m => nth m l h end 
+        with refl_equal => _ end).
+      reflexivity.
+    - inversion f.
+    - right.
+      inversion a as [e | n H e].
+      + refine (match e in (_ = df) return 
+          In match df with 0 => h | S m => nth m l h end l 
+          with refl_equal => _ end).
+        destruct l as [| ht l].
+        * apply 
+            (lt_irrefl _ (gt_le_trans _ _ _ a (gt_S_le _ _ (decode_Fin_inf_n f)))).
+        * left ; reflexivity.
+      + refine (match e in (_ = df) return 
+          In match df with 0 => h | S m => nth m l h end l 
+          with refl_equal => _ end).
+        assert (H': n < (length l)).
+        { apply lt_S_n.
+          rewrite e.
+          apply decode_Fin_inf_n. }
+        apply (nth_In _ _ H').
   Qed.
 
   Definition inf_length_lgtiM (n: nat)(l: list T)(h: n < length l)
@@ -376,33 +376,34 @@ Section Bij_ilistMult_list.
   Proof.
     destruct n as [|n]; intros l h t p;
     destruct l as [| hd l].
-    inversion h.
-    simpl.
-    rewrite code_Fin1_Sn_0.
-    reflexivity.
-    inversion h.
-    simpl in h.
-    simpl nth.
-    assert (h':= lt_le_S _ _ (lt_S_n _ _ h)).
-    assert (H: decode_Fin (code_Fin1_Sn (lt_n_Sm_le (S n) (length l) 
-      (inf_length_lgtiM (hd :: l) h p)))=
-    S n).
-    rewrite (code_Fin1_Sn_proofirr _ h').
-    revert n h h'.
-    induction (length l) as [| ll IHll] ; intros n h h'.
-    inversion h'.
-    rewrite code_Fin1_Sn_S.
-    simpl.
-    f_equal.
-    assert (h1 := le_S_n _ _ h').
-    rewrite (code_Fin1_Sn_proofirr _ h1).
-    destruct n as [|n].
-    rewrite code_Fin1_Sn_0.
-    reflexivity.
-    apply (IHll _ (lt_S_n _ _ h)).
-    simpl.
-    rewrite H.
-    apply (nth_indep_comp _ l t hd h').
+    - inversion h.
+    - cbn.
+      rewrite code_Fin1_Sn_0.
+      reflexivity.
+    - inversion h.
+    - cbn in h.
+      simpl nth.
+      assert (h':= lt_le_S _ _ (lt_S_n _ _ h)).
+      assert (H: decode_Fin (code_Fin1_Sn (lt_n_Sm_le (S n) (length l) 
+                               (inf_length_lgtiM (hd :: l) h p)))
+                 = S n).
+      { rewrite (code_Fin1_Sn_proofirr _ h').
+        revert n h h'.
+        induction (length l) as [| ll IHll] ; intros n h h'.
+        - inversion h'.
+        - rewrite code_Fin1_Sn_S.
+          cbn.
+          f_equal.
+          assert (h1 := le_S_n _ _ h').
+          rewrite (code_Fin1_Sn_proofirr _ h1).
+          destruct n as [|n].
+          + rewrite code_Fin1_Sn_0.
+            reflexivity.
+          + apply (IHll _ (lt_S_n _ _ h)).
+      }
+      cbn.
+      rewrite H.
+      apply (nth_indep_comp _ l t hd h').
   Qed.
     
   Lemma list2ilistM_nth2: forall (l: list T)(p: PropMult _ _ _)
@@ -413,21 +414,21 @@ Section Bij_ilistMult_list.
     unfold ffctiMult.
     unfold fctin.
     destruct l as [|hd l].
-    inversion f.
-    simpl.
-    simpl in f.
-    elim (zerop (decode_Fin f)); intros a.
-    rewrite a; reflexivity.
-    inversion a as [e| n H e] ; 
-    assert (h:= decode_Fin_inf_n f).
-    destruct l as [|hhd l].
-    rewrite <- e in h.
-    apply False_rec.
-    apply (lt_irrefl _ h).
-    reflexivity.
-    apply (nth_indep_comp _ _ _ _).
-    rewrite <- e in h.
-    apply (lt_S_n _ _ h).
+    - inversion f.
+    - cbn.
+      cbn in f.
+      elim (zerop (decode_Fin f)); intros a.
+      + rewrite a; reflexivity.
+      + inversion a as [e| n H e] ; 
+          assert (h:= decode_Fin_inf_n f).
+        destruct l as [|hhd l].
+        * rewrite <- e in h.
+          apply False_rec.
+          apply (lt_irrefl _ h).
+        * reflexivity.
+        * apply (nth_indep_comp _ _ _ _).
+          rewrite <- e in h.
+          apply (lt_S_n _ _ h).
   Qed.
     
   Lemma lgtiM_list2ilistM: forall (l: list T)(p: PropMult inf sup (length l)), 
@@ -443,10 +444,10 @@ Section Bij_ilistMult_list.
   Proof.
     intros i.
     set (p := match sym_eq (length_ilistM2list _) in (_=x) return PropMult _ _ x 
-    with refl_equal => (propin (fctiMult i)) end).
+      with refl_equal => (propin (fctiMult i)) end).
     assert (h : lgtiMult (list2ilistM (ilistM2list i) p) = lgtiMult i).
-    rewrite lgtiM_list2ilistM.
-    apply length_ilistM2list.
+    { rewrite lgtiM_list2ilistM.
+      apply length_ilistM2list. }
     apply (is_imeq _ _ _ h).
     intros f.
     rewrite <- (list2ilistM_nth2 _ _ _ 
@@ -461,24 +462,24 @@ Section Bij_ilistMult_list.
     comp (list2Fin_T (a :: l) (succ x)) (list2Fin_T l x).
   Proof.
    induction l as [|hd l]; intros a f.
-   inversion f.
-   simpl.
-   elim (zerop (decode_Fin f)); intros b.
-   refine (match (sym_eq b) as b' in ( _ = df) return 
-   (comp match df with 0 => hd | S m => _ end  
-    match df with 0 => hd | S m => _ end) with refl_equal => _ end).
-   reflexivity.
-   inversion b as [e | n H e].
-   destruct l as [|hhd l].
-   apply False_rec.
-   assert (H:= decode_Fin_inf_n f) ; simpl in H.
-   rewrite e in H.
-   apply (lt_irrefl _ H).
-   reflexivity.
-   assert (H1:= decode_Fin_inf_n f); simpl in H1.
-   rewrite <- e in H1.
-   apply (lt_S_n n (length l)) in H1.
-   apply (nth_indep_comp compRel l a hd H1).
+   - inversion f.
+   - cbn.
+     elim (zerop (decode_Fin f)); intros b.
+     + refine (match (sym_eq b) as b' in ( _ = df) return 
+       (comp match df with 0 => hd | S m => _ end  
+        match df with 0 => hd | S m => _ end) with refl_equal => _ end).
+       reflexivity.
+     + inversion b as [e | n H e].
+       * destruct l as [|hhd l].
+         -- apply False_rec.
+            assert (H:= decode_Fin_inf_n f) ; cbn in H.
+            rewrite e in H.
+            apply (lt_irrefl _ H).
+         -- reflexivity.
+       * assert (H1:= decode_Fin_inf_n f); cbn in H1.
+         rewrite <- e in H1.
+         apply (lt_S_n n (length l)) in H1.
+         apply (nth_indep_comp compRel l a hd H1).
   Qed.
 
   Lemma list2Fin_T_succ_map: 
@@ -487,11 +488,11 @@ Section Bij_ilistMult_list.
        (map (fun x : Fin (length l) => list2Fin_T (a :: l) (succ x)) lf).
   Proof.
     intros l a ; induction lf as [| hd lf].
-    apply ListEq_nil.
-    apply ListEq_cons.
-    rewrite list2Fin_T_succ.
-    reflexivity.
-    apply IHlf.
+    - apply ListEq_nil.
+    - apply ListEq_cons.
+      + rewrite list2Fin_T_succ.
+        reflexivity.
+      + apply IHlf.
   Qed.
 
 
@@ -502,18 +503,18 @@ Section Bij_ilistMult_list.
     unfold ilistM2list.
     unfold ffctiMult.
     unfold fctin.
-    simpl.
+    cbn.
     clear p.
     induction l as [|hd l].
-    reflexivity.
-    simpl.
-    apply ListEq_cons.
-    reflexivity.
-    rewrite (map_map_ListEq (A:= Fin (length l))(B:= Fin (S (length l))) 
-      compRel).
-    change (ListEq comp (map (fun x => list2Fin_T (hd::l) (succ x)) (makeListFin (length l))) l).
-    rewrite <- list2Fin_T_succ_map.
-    apply IHl.
+    - reflexivity.
+    - cbn.
+      apply ListEq_cons.
+      + reflexivity.
+      + rewrite (map_map_ListEq (A:= Fin (length l))(B:= Fin (S (length l))) 
+          compRel).
+        change (ListEq comp (map (fun x => list2Fin_T (hd::l) (succ x)) (makeListFin (length l))) l).
+        rewrite <- list2Fin_T_succ_map.
+        apply IHl.
   Qed.
 
   Program Definition ilistMM (n: nat)(p: PropMult inf sup n)
@@ -539,25 +540,24 @@ Section Bij_ilistMult_list.
   Proof.
     intros T eqT eqTRel i1 i2 ; split ; intros H ;
     destruct i1 as [n1 i1]; destruct i2 as [n2 i2].
-    destruct H as [e H].
-    simpl in e.
-    revert i2 H; rewrite <- e ; simpl ; clear e n2 ; intros i2 H.
-    unfold ilistM2list ; simpl.
-    destruct n1 as [|n1].
-    reflexivity.
-    simpl.
-    apply ListEq_cons.
-    apply H.
-    apply (ListEq_map_f_g _ _ _ _ H).
-
-    assert (H1 := ListEq_length H).
-    unfold ilistM2list in H1.
-    do 2 rewrite map_length, makeListFin_nb_elem_ok in H1 ; simpl in H1.
-    revert i2 H ; rewrite <- H1 ; clear n2 H1 ; intros i2 H.
-    apply (is_imeq _ _ _ (refl_equal _ :  
-      lgtiMult (existT (fun n : nat => ilistnMult T inf sup n) n1 i1) = 
-      lgtiMult (existT (fun n : nat => ilistnMult T inf sup n) n1 i2))) ; intro f.
-    apply (ListEq_eq eqTRel _ _ _ H _ (all_Fin_n_in_makeListFin f)).
+    - destruct H as [e H].
+      cbn in e.
+      revert i2 H; rewrite <- e ; cbn ; clear e n2 ; intros i2 H.
+      unfold ilistM2list ; cbn.
+      destruct n1 as [|n1].
+      + reflexivity.
+      + cbn.
+        apply ListEq_cons.
+        * apply H.
+        * apply (ListEq_map_f_g _ _ _ _ H).
+    - assert (H1 := ListEq_length H).
+      unfold ilistM2list in H1.
+      do 2 rewrite map_length, makeListFin_nb_elem_ok in H1 ; cbn in H1.
+      revert i2 H ; rewrite <- H1 ; clear n2 H1 ; intros i2 H.
+      apply (is_imeq _ _ _ (refl_equal _ :  
+          lgtiMult (existT (fun n : nat => ilistnMult T inf sup n) n1 i1) = 
+          lgtiMult (existT (fun n : nat => ilistnMult T inf sup n) n1 i2))) ; intro f.
+      apply (ListEq_eq eqTRel _ _ _ H _ (all_Fin_n_in_makeListFin f)).
   Qed.
 
   Lemma ListEq_imeq_eq: 
@@ -603,7 +603,7 @@ Section Bij_ilistMult_list.
       rewrite map_length.
       apply (sym_eq (length_ilistM2list i)). }
     apply (is_imeq _ _ _ H); intro fi ;
-    destruct i as [[|n] i].
+      destruct i as [[|n] i].
     { inversion fi. }
     cbn in H, p.
     rewrite <- (code1_decode_Id fi) at 1.
@@ -611,7 +611,7 @@ Section Bij_ilistMult_list.
     cbn.
     rewrite <- decode_Fin_match'.
     elim (zerop (decode_Fin fi)); intros a ;
-    destruct i as [i pp].
+      destruct i as [i pp].
     - refine (match (sym_eq a) in (_ = df) return 
       compU _ match df with 0 => f (i (first n)) | S m => _ end
       with refl_equal => _ end).
@@ -619,11 +619,9 @@ Section Bij_ilistMult_list.
       rewrite code_Fin1_Sn_0.
       reflexivity.
     - inversion a as [e | m H1 e].
-
       + destruct n as [|n].
         * rewrite (Fin_first_1 fi) in e.
           inversion e.
-
         * rewrite (decode_Fin_unique fi (succ (first n)) (sym_eq e)).
           cbn.
           rewrite code_Fin1_Sn_S.
@@ -631,10 +629,8 @@ Section Bij_ilistMult_list.
           reflexivity.
       + unfold ffctiMult.
         unfold fctin.
-        simpl.
-   
+        cbn.
         do 2 rewrite map_map.
-
         refine (match e in (_ = df) return 
                       compU _ match df with 0 => _ | S m => 
           nth m (List.map (fun x : Fin n => f (i (@succ n x))) (makeListFin n)) (f (i (first n)))
@@ -643,10 +639,9 @@ Section Bij_ilistMult_list.
         rewrite (map_map_nth_comp compTRel compURel i fM).
         assert (H2 := (lt_n_Sm_le (decode_Fin fi) n (decode_Fin_inf_n fi))).
         rewrite (code_Fin1_Sn_proofirr _ H2).
-        revert H2 ; simpl ; rewrite <- e; intro H2.
+        revert H2 ; cbn ; rewrite <- e; intro H2.
         destruct n as [|n].
         * inversion H2.
-
         * rewrite (nth_indep _ (first (S n)) (succ (first n))).
           -- rewrite map_nth.
              rewrite code_Fin1_Sn_S.
@@ -670,11 +665,11 @@ Section Bij_ilistMult_list.
   Proof.
     intros T U l a lf f compT compTRel compU compURel fM.
     induction lf as [| hd lf IHlf].
-    apply ListEq_nil.
-    apply ListEq_cons.
-    rewrite (list2Fin_T_succ compTRel).
-    reflexivity.
-    apply IHlf.
+    - apply ListEq_nil.
+    - apply ListEq_cons.
+      + rewrite (list2Fin_T_succ compTRel).
+        reflexivity.
+      + apply IHlf.
   Qed.
 
   Lemma iMMap_cons: forall (T U: Set)(a: T)(l: list T)(f: T -> U)
@@ -689,9 +684,9 @@ Section Bij_ilistMult_list.
     intros T U a l f inf sup p1 p2 compT compTRel compU compURel fM .
     rewrite (map_iMMap_ilistM_list (list2ilistM _ _ (a :: l) _) _ _ fM).
     rewrite (ilistM2list_list2ilistM_id compURel).
-    simpl.
+    cbn.
     apply ListEq_cons.
-    reflexivity.
+    { reflexivity. }
     unfold ilistM2list.
     do 2 (rewrite (map_map_ListEq compURel)).
     rewrite (list2Fin_T_succ_map_f l a _ compTRel compURel fM).
@@ -709,23 +704,23 @@ Section Bij_ilistMult_list.
     unfold ilistM2list.
     unfold ffctiMult.
     unfold fctin.
-    simpl.
+    cbn.
     clear p.
     induction l as [|hd l IHl].
-    reflexivity.
-    simpl.
+    { reflexivity. }
+    cbn.
     apply ListEq_cons.
-    reflexivity.
+    { reflexivity. }
     rewrite IHl.
     rewrite map_map.
-    destruct l as [|hhd l] ; simpl.
-    reflexivity.
+    destruct l as [|hhd l] ; cbn.
+    { reflexivity. }
     apply ListEq_cons.
-    reflexivity.
+    { reflexivity. }
     do 2 (rewrite map_map).
     apply ListEq_map_f_g.
     intro a.
-    simpl.
+    cbn.
     rewrite (nth_indep l hd hhd (decode_Fin_inf_n a)).
     reflexivity.
   Qed.
@@ -777,7 +772,7 @@ Section manip_ilistMult.
   Proof.
     intros T eqT eqTR p p' t.
     assert (h: lgtiMult (singletonM p t) = lgtiMult (iMcons t (iMnil T p') p)).
-    reflexivity.
+    { reflexivity. }
     apply (is_imeq _ _ _ h).
     intro f.
     rewrite <- (decode_Fin_unique _ _ (decode_Fin_match' f h)).
@@ -789,8 +784,8 @@ Section manip_ilistMult.
   Definition Sop (n: option nat): option nat.
   Proof.
     destruct n as [n|].
-    exact (Some (S n)).
-    exact None.
+    - exact (Some (S n)).
+    - exact None.
   Defined.
 
   Lemma Sop_Some: 
@@ -822,7 +817,7 @@ Section manip_ilistMult.
     eqT (ffctiMult i f) (ffctiMult (iMcons t i p) (succ f)).
   Proof.
     unfold ffctiMult ; unfold fctin.
-    unfold iMcons ;unfold iMconsn; unfold iconsn; unfold get_cons; simpl.
+    unfold iMcons; unfold iMconsn; unfold iconsn; unfold get_cons; cbn.
     intros T eqT eqTR t [[|n] i] f p.
     inversion f.
     reflexivity.

--- a/IlistPerm.v
+++ b/IlistPerm.v
@@ -1346,11 +1346,11 @@ Section IlistPerm_ind.
     Lemma IlistPerm3Cert_list_eq (n: nat)(c: IlistPerm3Cert_list n)(H: n = n) : 
       c = rewriteIlistPerm3Cert_list H c.
     Proof.
-      induction n as [|n IH] ; destruct c as [[i1 i2] c].
-      reflexivity.
-      simpl.
-      f_equal ; try f_equal ; try treatFinPure.
-      apply IH.
+      induction n as [|n IH]. 
+      - destruct c; reflexivity.
+      - destruct c as [[i1 i2] c]. simpl.
+        f_equal ; try f_equal ; try treatFinPure.
+        apply IH.
     Qed.
 
     Lemma rewriteIlistPerm3Cert_list_proofirr: forall (n1 n2: nat)(e1 e2: n1 = n2)

--- a/IlistPerm.v
+++ b/IlistPerm.v
@@ -42,19 +42,19 @@ Section Ilist_Perm_occ.
   as count_occM1.
   Proof.
     intros [n1 i1] [n2 i2] [h H].
-    simpl in h, H.
+    cbn in h, H.
     assert (h' := h) ; revert i2 h H ; rewrite <- h' ; intros i2 h H ; clear h' n2.
     fold (mkilist i1); fold (mkilist i2).
     assert (e1: forall f, f = rewriteFins h f).
-    intro f.
-    apply decode_Fin_unique, decode_Fin_match'.
+    { intro f.
+      apply decode_Fin_unique, decode_Fin_match'. }
     assert (H': forall f, RelT (i1 f) (i2 f)).
-    intro f ; rewrite (e1 f) at 2 ; apply H. 
+    { intro f ; rewrite (e1 f) at 2 ; apply H. }
     clear h H e1.
-    simpl.
+    cbn.
     induction n1 as [|n IH].
-    reflexivity.
-    simpl.
+    { reflexivity. }
+    cbn.
     destruct RelTEq as [Rrefl Rsym Rtrans].
     elim (R_dec t (i1 (first n))) ; intros a ;
     elim (R_dec t (i2 (first n))) ; intros c ;
@@ -80,20 +80,20 @@ Section Ilist_Perm_occ.
      exists m, count_occn RelT R_dec (l i) l = S m.
   Proof.
     induction i.
-    simpl.
-    elim (R_dec (l (first k)) (l (first k))) ; intros a.
-    exists (count_occn RelT R_dec (l (first k)) (fun f : Fin k => l (succ f))).
-    reflexivity.
-    unfold not in a.
-    contradiction a.
-    reflexivity.
-    simpl.
-    elim (R_dec (l (succ i)) (l (first k))) ; intros a.
-    exists (count_occn RelT R_dec (l (succ i)) (fun f : Fin k => l (succ f))).
-    reflexivity.
-    destruct (IHi (fun f : Fin k => l (succ f))) as [m H].
-    exists m.
-    apply H.
+    - cbn.
+      elim (R_dec (l (first k)) (l (first k))) ; intros a.
+      + exists (count_occn RelT R_dec (l (first k)) (fun f : Fin k => l (succ f))).
+        reflexivity.
+      + unfold not in a.
+        contradiction a.
+        reflexivity.
+    - cbn.
+      elim (R_dec (l (succ i)) (l (first k))) ; intros a.
+      + exists (count_occn RelT R_dec (l (succ i)) (fun f : Fin k => l (succ f))).
+        reflexivity.
+      + destruct (IHi (fun f : Fin k => l (succ f))) as [m H].
+        exists m.
+        apply H.
   Qed.
 
   Lemma count_occn_not_exist (T: Set)(RelT: relation T)
@@ -102,15 +102,15 @@ Section Ilist_Perm_occ.
    Proof.
      intros H.
      induction n as [|n IH].
-     reflexivity.
-     simpl.
+     { reflexivity. }
+     cbn.
      elim (R_dec t (l (first n))) ; intros a.
-     destruct H.
-     exists (first n) ; assumption.
-     apply IH.
-     intros [f H'].
-     destruct H.
-     exists (succ f) ; assumption.
+     - destruct H.
+       exists (first n) ; assumption.
+     - apply IH.
+       intros [f H'].
+       destruct H.
+       exists (succ f) ; assumption.
    Qed.
 
   Lemma count_occn_exist (T: Set)(RelT: relation T)
@@ -119,13 +119,13 @@ Section Ilist_Perm_occ.
    Proof.
      intro H.
      induction n as [|n IH].
-     inversion H.
-     simpl in H.
+     { inversion H. }
+     cbn in H.
      revert H.
-     elim (R_dec t (l (first n))) ; simpl ; intros a H.
-     exists (first n) ; assumption.
-     destruct (IH (fun x => l (succ x)) H) as [f H'].
-     exists (succ f) ; assumption.
+     elim (R_dec t (l (first n))) ; cbn ; intros a H.
+     - exists (first n) ; assumption.
+     - destruct (IH (fun x => l (succ x)) H) as [f H'].
+       exists (succ f) ; assumption.
    Qed.
 
   Lemma IlistPerm_refl: forall (T: Set)(RelT: relation T)
@@ -174,10 +174,10 @@ Section Ilist_Perm_occ.
    Proof.
      intros t1 t2 H.
      destruct i as [n i].
-     simpl.
+     cbn.
      induction n as [|n IH].
-     reflexivity.
-     simpl.
+     { reflexivity. }
+     cbn.
      destruct REq as [Rrefl Rsym Rtrans].
      elim (R_dec t1 (i (first n))) ; intros a ;
      elim (R_dec t2 (i (first n))) ; intros b ;
@@ -195,25 +195,25 @@ Section Ilist_Perm_occ.
      intros T RelT [Rrefl Rsym Rtrans] R_dec [n i1] [n2 i2] [h H].
      apply is_IlistPerm.
      intros t.
-     simpl in *|-*.
+     cbn in *|-*.
      assert (h' := h) ; revert i1 i2 h H ; rewrite <- h' ; intros i1 i2 h H ; clear h' n2.
      assert (H1 : forall f, RelT (i1 f) (i2 f)).
-     intro f.
-     rewrite (decode_Fin_unique _ _ (decode_Fin_match' f h)) at 2.
-     apply (H f).
+     { intro f.
+       rewrite (decode_Fin_unique _ _ (decode_Fin_match' f h)) at 2.
+       apply (H f). }
      clear H h.
-
      induction n as [|n IH].
-     reflexivity.
-     simpl.
+     { reflexivity. }
+     cbn.
      elim (R_dec t (i1 (first n))) ; elim (R_dec t (i2 (first n))) ; intros a b.
-     f_equal ; apply IH.
-     intro f ; apply (H1 (succ f)).
-     contradiction (Rtrans _ _ _ b (H1 (first n))).
-     contradiction (Rtrans _ _ _ a (Rsym _ _ (H1 (first n)))).
-     apply IH.
-     intro f ; apply (H1 (succ f)).
+     - f_equal ; apply IH.
+       intro f ; apply (H1 (succ f)).
+     - contradiction (Rtrans _ _ _ b (H1 (first n))).
+     - contradiction (Rtrans _ _ _ a (Rsym _ _ (H1 (first n)))).
+     - apply IH.
+       intro f ; apply (H1 (succ f)).
    Qed.
+   
 End Ilist_Perm_occ.
 
 Section IlistPerm_ind.
@@ -246,7 +246,7 @@ Section IlistPerm_ind.
        match h with is_IlistPerm4 i1 i2 h1 h2 => _ end).
      clear i00 i0 h.
      apply H.
-     assumption.
+     { assumption. }
      intro f1.
      destruct (h2 f1) as [f2 [h3 h4]].
      exists f2.
@@ -272,7 +272,7 @@ Section IlistPerm_ind.
        match h with is_IlistPerm5 i1 i2 h1 h2 => _ end).
      clear i00 i0 h.
      apply H.
-     assumption.
+     { assumption. }
      intro f2.
      destruct (h2 f2) as [f1 [h3 h4]].
      exists f1.
@@ -285,7 +285,7 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT i1 i2 H.
      induction H as [i1 i2 h1 h2 | i1 i2 f1 f2 h1 h2 IH].
-     assumption.
+     { assumption. }
      apply eq_S in IH.
      do 2 rewrite <- extroduce_lgti in IH.
      assumption.
@@ -302,13 +302,13 @@ Section IlistPerm_ind.
      fold (mkilist i1) in *|-*.
      fold (mkilist i2) in *|-*.
      destruct n1 as [|n1].
-     apply IlistPerm3_nil.
-     assumption.
-     reflexivity.
-     destruct (h2 (first n1)) as [f2 [h3 [h4 h5]]] ; clear h2.
-     clear h4.
-     apply (IlistPerm3_cons _ _ (first _: Fin (lgti (mkilist _))) 
-       (f2: Fin (lgti (mkilist _)))) ; assumption.
+     - apply IlistPerm3_nil.
+       + assumption.
+       + reflexivity.
+     - destruct (h2 (first n1)) as [f2 [h3 [h4 h5]]] ; clear h2.
+       clear h4.
+       apply (IlistPerm3_cons _ _ (first _: Fin (lgti (mkilist _))) 
+         (f2: Fin (lgti (mkilist _)))) ; assumption.
      Qed.
      
    Lemma IlistPerm5_IlistPerm3_eq : forall (T: Set)(RelT: relation T)(i1 i2: ilist T), 
@@ -321,11 +321,11 @@ Section IlistPerm_ind.
      fold (mkilist i1) in *|-*.
      fold (mkilist i2) in *|-*.
      destruct n2 as [|n2].
-     apply IlistPerm3_nil ; assumption.
-     destruct (h2 (first n2)) as [f1 [h3 [h4 h5]]] ; clear h2.
-     clear h4.
-     apply (IlistPerm3_cons _ _ (f1 : Fin (lgti (mkilist _))) 
-       (first _: Fin (lgti (mkilist _)))) ; assumption.
+     - apply IlistPerm3_nil ; assumption.
+     - destruct (h2 (first n2)) as [f1 [h3 [h4 h5]]] ; clear h2.
+       clear h4.
+       apply (IlistPerm3_cons _ _ (f1 : Fin (lgti (mkilist _))) 
+         (first _: Fin (lgti (mkilist _)))) ; assumption.
     Qed.
 
    Lemma IlistPerm4_refl_refl: forall (T: Set)(RelT: relation T)(Rrefl: Reflexive RelT)(i: ilist T),
@@ -336,13 +336,13 @@ Section IlistPerm_ind.
      apply (is_IlistPerm4 _ _ (refl_equal _)) ;
      simpl lgti ; simpl fcti ;
      intro f ; exists f.
-     inversion f.
-     split.
-     reflexivity.
-     set (e := extroduce (existT (fun n0 : nat => ilistn T n0) (S n) i) f).
-     assert (h:= extroduce_lgti_S _ _ : n = lgti e).
-     destruct e as [n' e].
-     simpl in h ; revert e ; rewrite <- h ; intro e ; apply IH.
+     - inversion f.
+     - split.
+       + reflexivity.
+       + set (e := extroduce (existT (fun n0 : nat => ilistn T n0) (S n) i) f).
+         assert (h:= extroduce_lgti_S _ _ : n = lgti e).
+         destruct e as [n' e].
+         cbn in h ; revert e ; rewrite <- h ; intro e ; apply IH.
    Qed.
 
    Lemma IlistPerm4_refl: forall (T: Set)(RelT: relation T)(EqT: Equivalence RelT)(i: ilist T),
@@ -353,17 +353,17 @@ Section IlistPerm_ind.
      apply (is_IlistPerm4 _ _ (refl_equal _)) ;
      simpl lgti ; simpl fcti ;
      intro f ; exists f.
-     inversion f.
-     split.
-     apply Rrefl.
-     set (e := extroduce (existT (fun n0 : nat => ilistn T n0) (S n) i) f).
-     assert (h: lgti e = n).
-     apply eq_add_S.
-     unfold e.
-     rewrite <- extroduce_lgti.
-     reflexivity.
-     destruct e as [n' e].
-     simpl in h ; revert e ; rewrite h ; intro e ; apply IH.
+     - inversion f.
+     - split.
+       + apply Rrefl.
+       + set (e := extroduce (existT (fun n0 : nat => ilistn T n0) (S n) i) f).
+         assert (h: lgti e = n).
+         { apply eq_add_S.
+           unfold e.
+           rewrite <- extroduce_lgti.
+           reflexivity. }
+         destruct e as [n' e].
+         cbn in h ; revert e ; rewrite h ; intro e ; apply IH.
    Qed.
 
    (* Deduced from IlistPerm4_refl *)
@@ -396,8 +396,8 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT i1 i2.
      apply is_IlistPerm4.
-     reflexivity.
-     intro f1 ; inversion f1.
+     - reflexivity.
+     - intro f1 ; inversion f1.
    Qed.
 
    Lemma IlistPerm4nil_gen: forall (T: Set)(RelT: relation T)(i1 i2: ilist T), 
@@ -406,11 +406,11 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT i1 i2 Hyp1 Hyp2.
      apply is_IlistPerm4.
-     exact Hyp1.
-     intro f1.
-     apply False_rec.
-     rewrite Hyp2 in f1.
-     inversion f1.
+     - exact Hyp1.
+     - intro f1.
+       apply False_rec.
+       rewrite Hyp2 in f1.
+       inversion f1.
    Qed.
 
    Lemma IlistPerm4_lgti: forall (T: Set)(RelT: relation T)(i1 i2: ilist T), 
@@ -424,8 +424,8 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT i1 i2 ; intros h ;
      induction h as [i1 i2 e1 e2 | i1 i2 f1 f2 h1 _ IH].
-     apply (IlistPerm3_nil _ _ _ (sym_eq e1) (trans_eq (sym_eq e1) e2)).
-     apply (IlistPerm3_cons _ _ f2 f1) ; assumption.
+     - apply (IlistPerm3_nil _ _ _ (sym_eq e1) (trans_eq (sym_eq e1) e2)).
+     - apply (IlistPerm3_cons _ _ f2 f1) ; assumption.
    Qed.
 
    Lemma IlistPerm3_flip': forall (T: Set)(RelT: relation T)(i1 i2: ilist T), 
@@ -433,8 +433,8 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT i1 i2 ; intros h ;
      induction h as [i1 i2 e1 e2 | i1 i2 f1 f2 h1 h2 IH].
-     apply (IlistPerm3_nil _ _ _ (sym_eq e1) (trans_eq (sym_eq e1) e2)).
-     apply (IlistPerm3_cons _ _ f2 f1); assumption.
+     - apply (IlistPerm3_nil _ _ _ (sym_eq e1) (trans_eq (sym_eq e1) e2)).
+     - apply (IlistPerm3_cons _ _ f2 f1); assumption.
    Qed.
 
    (* using IlistPerm3_flip *)
@@ -444,10 +444,10 @@ Section IlistPerm_ind.
      intros T RelT [_ Rsym _] i1 i2 h.
      assert (h1 := IlistPerm3_flip h) ; clear h.
      induction h1 as  [i2 i1 e1 e2 | i2 i1 f2 f1 h1 _ IH].
-     apply (IlistPerm3_nil _ _ _ e1 e2).
-     apply (IlistPerm3_cons _ _ f2 f1).
-     apply (Rsym _ _ h1).
-     assumption.
+     - apply (IlistPerm3_nil _ _ _ e1 e2).
+     - apply (IlistPerm3_cons _ _ f2 f1).
+       + apply (Rsym _ _ h1).
+       + assumption.
    Qed.
 
    Lemma IlistPerm3_sym_sym: forall (T: Set)(RelT: relation T)(Rsym: Symmetric RelT)(i1 i2: ilist T), 
@@ -456,10 +456,10 @@ Section IlistPerm_ind.
      intros T RelT Rsym i1 i2 h.
      assert (h1 := IlistPerm3_flip h) ; clear h.
      induction h1 as  [i1 i2 e1 e2 | i1 i2 f1 f2 h1 h2 IH].
-     apply (IlistPerm3_nil _ _ _ e1 e2).
-     apply (IlistPerm3_cons _ _ f1 f2).
-     apply (Rsym _ _ h1).
-     assumption.
+     - apply (IlistPerm3_nil _ _ _ e1 e2).
+     - apply (IlistPerm3_cons _ _ f1 f2).
+       + apply (Rsym _ _ h1).
+       + assumption.
    Qed.
 
    Definition TransitiveAt (T: Type)(R: relation T)(t1: T): Prop :=
@@ -476,18 +476,18 @@ Section IlistPerm_ind.
     intros i1 h1 Hyp.
     destruct h1 as [i1 i2 e1 h1].
     apply is_IlistPerm4.
-    apply (trans_eq e1 e2).
-    intro f1.
-    destruct (h1 f1) as [f2 [h11 h12]] ; clear h1.
-    destruct (h2 f2) as [f3 [h21 [h22 h23]]] ; clear h2.
-    exists f3.
-    split.
-    apply (Hyp _ _ _ h11 h21).
-    apply (h23 _ h12).
-    intro f0.
-    destruct (extroduce_ok_cor i1 f1 f0).
-    rewrite H.
-    apply Hyp.
+    - apply (trans_eq e1 e2).
+    - intro f1.
+      destruct (h1 f1) as [f2 [h11 h12]] ; clear h1.
+      destruct (h2 f2) as [f3 [h21 [h22 h23]]] ; clear h2.
+      exists f3.
+      split.
+      + apply (Hyp _ _ _ h11 h21).
+      + apply (h23 _ h12).
+        intro f0.
+        destruct (extroduce_ok_cor i1 f1 f0).
+        rewrite H.
+        apply Hyp.
    Qed.
 
 (* obviously, the following lemma is just a special case *)
@@ -537,8 +537,8 @@ Section IlistPerm_ind.
      destruct (h2 f2) as [f1 [h3 [_ h4]]].
      exists f1.
      split.
-     apply (Rsym _ _ h3).
-     assumption.
+     - apply (Rsym _ _ h3).
+     - assumption.
    Qed.
 
    Lemma IlistPerm5_flip_IlistPerm4 : forall (T: Set)(RelT: relation T)(i1 i2: ilist T), 
@@ -564,8 +564,8 @@ Section IlistPerm_ind.
      destruct (h2 f2) as [f1 [h3 [_ h4]]].
      exists f1.
      split.
-     apply (Rsym _ _ h3).
-     assumption.
+     - apply (Rsym _ _ h3).
+     - assumption.
    Qed.
 
    (* deduced from IlistPerm4_refl *)
@@ -574,8 +574,8 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT EqT i.
      apply IlistPerm4_sym_IlistPerm5.
-     destruct EqT as [_ Rsym _] ; assumption.
-     apply (IlistPerm4_refl EqT).
+     - destruct EqT as [_ Rsym _] ; assumption.
+     - apply (IlistPerm4_refl EqT).
    Qed.
 
    (* Proof by induction on IlistPerm4 *)
@@ -593,31 +593,30 @@ Section IlistPerm_ind.
      destruct (h2 (rewriteFins e1 f1)) as [f3 [h3 [h4 IH]]].
      exists f3.
      split.
-     destruct EqT as [_ _ Rtrans].
-     apply (Rtrans _ _ _ (h1' f1) h3).
-     apply IH.
-     assert (h : lgti (extroduce i1' f1) = lgti (extroduce i1 (rewriteFins e1 f1))).
-     evalLgtiExtro.
-     assumption.
-     apply (is_ilist_rel _ _ _ h).
-     intro f.
-     elim (le_lt_dec (decode_Fin f1) (decode_Fin f)) ; intros a.
-     rewrite extroduce_ok3' ; try assumption.
-     rewrite extroduce_ok3' by (treatFin a).
-     assert (h5: rewriteFins (sym_eq (extroduce_lgti i1 (rewriteFins e1 f1))) (succ (rewriteFins h f)) =
-                 rewriteFins e1 (rewriteFins (sym_eq (extroduce_lgti i1' f1)) (succ f))).
-     treatFinPure.
-     rewrite h5.
-     apply h1'.
-
-     rewrite extroduce_ok2' ; try assumption.
-     rewrite extroduce_ok2' by (treatFin a).
-     assert (h5: rewriteFins (sym_eq (extroduce_lgti i1 (rewriteFins e1 f1)))
-        (weakFin (rewriteFins h f)) = rewriteFins e1
-        (rewriteFins (sym_eq (extroduce_lgti i1' f1)) (weakFin f))).
-     treatFinPure.
-     rewrite h5.
-     apply h1'.
+     - destruct EqT as [_ _ Rtrans].
+       apply (Rtrans _ _ _ (h1' f1) h3).
+     - apply IH.
+       assert (h : lgti (extroduce i1' f1) = lgti (extroduce i1 (rewriteFins e1 f1))).
+       { evalLgtiExtro.
+         assumption. }
+       apply (is_ilist_rel _ _ _ h).
+       intro f.
+       elim (le_lt_dec (decode_Fin f1) (decode_Fin f)) ; intros a.
+       + rewrite extroduce_ok3' ; try assumption.
+         rewrite extroduce_ok3' by (treatFin a).
+         assert (h5: rewriteFins (sym_eq (extroduce_lgti i1 (rewriteFins e1 f1))) (succ (rewriteFins h f)) =
+                     rewriteFins e1 (rewriteFins (sym_eq (extroduce_lgti i1' f1)) (succ f))).
+         { treatFinPure. }
+         rewrite h5.
+         apply h1'.
+       + rewrite extroduce_ok2' ; try assumption.
+         rewrite extroduce_ok2' by (treatFin a).
+         assert (h5: rewriteFins (sym_eq (extroduce_lgti i1 (rewriteFins e1 f1)))
+            (weakFin (rewriteFins h f)) = rewriteFins e1
+            (rewriteFins (sym_eq (extroduce_lgti i1' f1)) (weakFin f))).
+         * treatFinPure.
+         * rewrite h5.
+           apply h1'.
    Qed.
 
    (* Proof with induction on IlistPerm3 *)
@@ -627,34 +626,33 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT EqT i1 i1' i2 h1 h2.
      revert i1' h1 ; induction h2 as [i1 i2 e2 e3 | i1 i2 f1 f2 e2 h2 IH] ; intros i1' [e1 h1].
-     apply (IlistPerm3_nil _ _ _ (trans_eq (sym_eq e1) e2) (trans_eq (sym_eq e1) e3)).
-     apply (IlistPerm3_cons _ _ (rewriteFins e1 f1) f2).
-     destruct EqT as [_ Rsym Rtrans].
-     apply (Rtrans _ _ _ (Rsym _ _ (h1 f1)) e2).
-     apply IH.
-     assert (h3: lgti (extroduce i1 f1) = lgti (extroduce i1' (rewriteFins e1 f1))).
-     evalLgtiExtro.
-     assumption.
-     apply (is_ilist_rel _ _ _ h3).
-     intro f.
-     elim (le_lt_dec (decode_Fin f1) (decode_Fin f)) ; intros a.
-(* continue as for IlistPerm4_ilist_rel (only variable names have changed) *)
-     rewrite extroduce_ok3' ; try assumption.
-     rewrite extroduce_ok3' by (treatFin a).
-     assert (h4: rewriteFins (sym_eq (extroduce_lgti i1' (rewriteFins e1 f1))) (succ (rewriteFins h3 f)) =
-                 rewriteFins e1 (rewriteFins (sym_eq (extroduce_lgti i1 f1)) (succ f))).
-     treatFinPure.
-     rewrite h4.
-     apply h1.
-
-     rewrite extroduce_ok2' ; try assumption.
-     rewrite extroduce_ok2' by (treatFin a).
-     assert (h5: rewriteFins (sym_eq (extroduce_lgti i1' (rewriteFins e1 f1)))
-        (weakFin (rewriteFins h3 f)) = rewriteFins e1
-        (rewriteFins (sym_eq (extroduce_lgti i1 f1)) (weakFin f))).
-     treatFinPure.
-     rewrite h5.
-     apply h1.
+     - apply (IlistPerm3_nil _ _ _ (trans_eq (sym_eq e1) e2) (trans_eq (sym_eq e1) e3)).
+     - apply (IlistPerm3_cons _ _ (rewriteFins e1 f1) f2).
+       + destruct EqT as [_ Rsym Rtrans].
+         apply (Rtrans _ _ _ (Rsym _ _ (h1 f1)) e2).
+       + apply IH.
+         assert (h3: lgti (extroduce i1 f1) = lgti (extroduce i1' (rewriteFins e1 f1))).
+         { evalLgtiExtro.
+           assumption. }
+         apply (is_ilist_rel _ _ _ h3).
+         intro f.
+         elim (le_lt_dec (decode_Fin f1) (decode_Fin f)) ; intros a.
+         (* continue as for IlistPerm4_ilist_rel (only variable names have changed) *)
+         * rewrite extroduce_ok3' ; try assumption.
+           rewrite extroduce_ok3' by (treatFin a).
+           assert (h4: rewriteFins (sym_eq (extroduce_lgti i1' (rewriteFins e1 f1))) (succ (rewriteFins h3 f)) =
+                       rewriteFins e1 (rewriteFins (sym_eq (extroduce_lgti i1 f1)) (succ f))).
+           { treatFinPure. }
+           rewrite h4.
+           apply h1.
+         * rewrite extroduce_ok2' ; try assumption.
+           rewrite extroduce_ok2' by (treatFin a).
+           assert (h5: rewriteFins (sym_eq (extroduce_lgti i1' (rewriteFins e1 f1)))
+              (weakFin (rewriteFins h3 f)) = rewriteFins e1
+              (rewriteFins (sym_eq (extroduce_lgti i1 f1)) (weakFin f))).
+           { treatFinPure. }
+           rewrite h5.
+           apply h1.
    Qed.
 
    Lemma IlistPerm3_ilist_rel_eq: forall (T: Set)(RelT: relation T)(l1 l1' l2 : ilist T)
@@ -663,13 +661,13 @@ Section IlistPerm_ind.
      intros T RelT l1 l1' l2 h1 h2.
      revert l1' h1 ; induction h2 as [l1 l2 e2 e3 | l1 l2 i1 i2 e2 h2 IH] ; intros l1' h1 ;
      inversion h1 as [e1 h1'].
-     apply (IlistPerm3_nil _ _ _ (trans_eq (sym_eq e1) e2) (trans_eq (sym_eq e1) e3)).
-     apply (IlistPerm3_cons _ _ (rewriteFins e1 i1) i2).
-     rewrite <- (h1' i1).
-     assumption.
-     apply IH.
-     apply extroduce_ilist_rel_bis.
-     assumption.
+     - apply (IlistPerm3_nil _ _ _ (trans_eq (sym_eq e1) e2) (trans_eq (sym_eq e1) e3)).
+     - apply (IlistPerm3_cons _ _ (rewriteFins e1 i1) i2).
+       + rewrite <- (h1' i1).
+         assumption.
+       + apply IH.
+         apply extroduce_ilist_rel_bis.
+         assumption.
    Qed.
 
 (* just a dual proof for the changes in the second argument *)
@@ -721,37 +719,37 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT [n l1] [n2 l2] H.
      inversion H as [h2 _].
-     simpl in h2.
+     cbn in h2.
      revert l2 H ; rewrite <- h2 ; intros l2 H ; clear n2 h2.
      induction n as [|n IH].
-     destruct H as [h H] ; simpl in *|-*.
-     apply IlistPerm3_nil ; reflexivity.
-     assert (i := first n).
-     apply (IlistPerm3_cons _ _ (i: Fin (lgti (existT (fun n0 : nat => ilistn T n0) (S n) l1))) 
-       (i: Fin (lgti (existT (fun n0 : nat => ilistn T n0) (S n) l2)))).
-     destruct H as [h H].
-     assert (H1: forall i, RelT (l1 i) (l2 i)).
-     intro i'. 
-     assert (h' : i' = rewriteFins h i').
-     unfold rewriteFins; apply decode_Fin_unique, decode_Fin_match.
-     rewrite h' at 2 ; apply (H i').
-     clear h H.
-     apply H1.
-     assert (H1 := extroduce_ilist_rel i H).
-     revert H1 ; unfold mkilist.
-     set (l1' := extroduce (existT (fun n0 : nat => ilistn T n0) (S n) l1) i).
-     set (l2' := extroduce (existT (fun n0 : nat => ilistn T n0) (S n) l2) i).
-     intro H1.
-     assert (h: lgti l1' = n).
-     unfold l1' ; apply eq_add_S.
-     rewrite <- extroduce_lgti.
-     reflexivity.
-     destruct l1' as [n' l1'] ; destruct l2' as [n2 l2'].
-     inversion H1 as [h1 _].
-     simpl in *|-*.
-     revert l1' l2' H1.
-     rewrite <- h1, h.
-     apply IH.
+     - destruct H as [h H] ; cbn in *|-*.
+       apply IlistPerm3_nil ; reflexivity.
+     - assert (i := first n).
+       apply (IlistPerm3_cons _ _ (i: Fin (lgti (existT (fun n0 : nat => ilistn T n0) (S n) l1))) 
+         (i: Fin (lgti (existT (fun n0 : nat => ilistn T n0) (S n) l2)))).
+       + destruct H as [h H].
+         assert (H1: forall i, RelT (l1 i) (l2 i)).
+         { intro i'. 
+           assert (h' : i' = rewriteFins h i').
+           unfold rewriteFins; apply decode_Fin_unique, decode_Fin_match.
+           rewrite h' at 2 ; apply (H i'). }
+         clear h H.
+         apply H1.
+       + assert (H1 := extroduce_ilist_rel i H).
+         revert H1 ; unfold mkilist.
+         set (l1' := extroduce (existT (fun n0 : nat => ilistn T n0) (S n) l1) i).
+         set (l2' := extroduce (existT (fun n0 : nat => ilistn T n0) (S n) l2) i).
+         intro H1.
+         assert (h: lgti l1' = n).
+         { unfold l1' ; apply eq_add_S.
+           rewrite <- extroduce_lgti.
+           reflexivity. }
+         destruct l1' as [n' l1'] ; destruct l2' as [n2 l2'].
+         inversion H1 as [h1 _].
+         cbn in *|-*.
+         revert l1' l2' H1.
+         rewrite <- h1, h.
+         apply IH.
    Qed.
   
    Lemma ilist_rel_finer_IlistPerm4: forall (T: Set)(RelT: relation T)
@@ -759,27 +757,27 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT [n l1] [n2 l2] h.
      inversion h as [h2 _].
-     simpl in h2.
+     cbn in h2.
      revert l2 h ; rewrite <- h2 ; intros l2 h ; clear n2 h2.
      fold (mkilist l1) (mkilist l2).
      induction n as [|n IH].
-     apply IlistPerm4nil.
+     { apply IlistPerm4nil. }
      apply (is_IlistPerm4 _ _ (refl_equal _ : lgti (mkilist l1) = lgti (mkilist l2))).
      intro i.
      inversion h as [e h'].
      simpl lgti in *|-* ; simpl fcti in *|-*.
      exists i.
      split.
-     rewrite (decode_Fin_unique _ _ (decode_Fin_match' i e)) at 2.
-     apply h'.
-     assert (hex := extroduce_ilist_rel i h).
-     revert hex.
-     set (l1' := extroduce (mkilist l1) i) ; set (l2' := extroduce (mkilist l2) i) ; 
-     assert (h1 := extroduce_lgti_S l1 i :n = lgti l1') ; assert (h2 := extroduce_lgti_S l2 i :n = lgti l2').
-     destruct l1' as [n1 l1'] ; destruct l2' as [n2 l2'].
-     simpl in h1, h2.
-     revert l1' l2' ; rewrite <- h1, <- h2 ; clear n1 n2 h1 h2.
-     apply IH.
+     - rewrite (decode_Fin_unique _ _ (decode_Fin_match' i e)) at 2.
+       apply h'.
+     - assert (hex := extroduce_ilist_rel i h).
+       revert hex.
+       set (l1' := extroduce (mkilist l1) i) ; set (l2' := extroduce (mkilist l2) i) ; 
+         assert (h1 := extroduce_lgti_S l1 i :n = lgti l1') ; assert (h2 := extroduce_lgti_S l2 i :n = lgti l2').
+       destruct l1' as [n1 l1'] ; destruct l2' as [n2 l2'].
+       cbn in h1, h2.
+       revert l1' l2' ; rewrite <- h1, <- h2 ; clear n1 n2 h1 h2.
+       apply IH.
    Qed.
 
    Lemma IlistPerm3_imap (T U: Set)(RelT: relation T)(RelU: relation U)
@@ -787,13 +785,13 @@ Section IlistPerm_ind.
      IlistPerm3 RelT l1 l2 -> IlistPerm3 RelU (imap f l1) (imap f l2).
    Proof.
      intro H ; induction H as [[n1 l1] [n2 l2] e1 e2 | l1 l2 i1 i2 h2 H IH].
-     apply IlistPerm3_nil ; assumption.
+     { apply IlistPerm3_nil ; assumption. }
      apply (IlistPerm3_cons _ _ (i1 : Fin (lgti(imap f l1))) (i2: Fin (lgti (imap f l2)))).
-     simpl.
-     apply fM, h2.
-     apply (IlistPerm3_ilist_rel_eq (ilist_rel_sym _ (extroduce_imap f l1 i1))).
-     apply (IlistPerm3_ilist_rel_eq_snd (ilist_rel_sym _ (extroduce_imap f l2 i2))).
-     apply IH.
+     - cbn.
+       apply fM, h2.
+     - apply (IlistPerm3_ilist_rel_eq (ilist_rel_sym _ (extroduce_imap f l1 i1))).
+       apply (IlistPerm3_ilist_rel_eq_snd (ilist_rel_sym _ (extroduce_imap f l2 i2))).
+       apply IH.
    Qed.
 
   Lemma IlistPerm3_imap_bis (A B: Set)(Rel: relation B)(f1 f2: A -> B)(l1 l2: ilist A):
@@ -801,17 +799,17 @@ Section IlistPerm_ind.
    Proof.
      intro Hyp.
      induction Hyp as [l1 l2 Hyp1 Hyp2 | l1 l2 i1 i2 H1 _ IH].
-     apply IlistPerm3_nil ; assumption.
+     { apply IlistPerm3_nil ; assumption. }
      apply (IlistPerm3_cons _ _ (i1 : Fin (lgti (imap f1 l1))) (i2 : Fin (lgti (imap f2 l2)))).
-     assumption.
-     assert (H7 := extroduce_imap f1 l1 i1).
-     apply ilist_rel_sym in H7 ; try apply eq_equivalence.
-     apply (IlistPerm3_ilist_rel_eq H7).
-     clear H7.
-     assert (H7 := extroduce_imap f2 l2 i2).
-     apply ilist_rel_sym in H7 ; try apply eq_equivalence.
-     apply (IlistPerm3_ilist_rel_eq_snd H7).
-     assumption.
+     - assumption.
+     - assert (H7 := extroduce_imap f1 l1 i1).
+      apply ilist_rel_sym in H7 ; try apply eq_equivalence.
+      apply (IlistPerm3_ilist_rel_eq H7).
+      clear H7.
+      assert (H7 := extroduce_imap f2 l2 i2).
+      apply ilist_rel_sym in H7 ; try apply eq_equivalence.
+      apply (IlistPerm3_ilist_rel_eq_snd H7).
+      assumption.
    Qed.
 
    Lemma IlistPerm3_imap_back (A B: Set)(Rel: relation B)
@@ -820,21 +818,21 @@ Section IlistPerm_ind.
    Proof.
      remember (lgti l1) as n.
      revert l1 l2 Heqn ; induction n as [|n IH] ; intros l1 l2 H H1. 
-     apply IlistPerm3_nil.
-     apply (IlistPerm3_lgti H1).
-     symmetry ; assumption.
-     inversion_clear H1 as [H2 H3 | i1 i2 H2 H3].
-     simpl in H3 ; rewrite <- H in H3.
-     inversion H3.
-     simpl in i1, i2, H2.
-     apply (IlistPerm3_cons _ _ i1 i2).
-     assumption.
-     apply IH.
-     evalLgtiExtro.
-     apply H.
-     assert (H4 := extroduce_imap f1 l1 i1).
-     assert (H5 := extroduce_imap f2 l2 i2).
-     apply (IlistPerm3_ilist_rel_eq H4), (IlistPerm3_ilist_rel_eq_snd H5), H3.
+     - apply IlistPerm3_nil.
+       + apply (IlistPerm3_lgti H1).
+       + symmetry ; assumption.
+     - inversion_clear H1 as [H2 H3 | i1 i2 H2 H3].
+       + cbn in H3 ; rewrite <- H in H3.
+         inversion H3.
+       + cbn in i1, i2, H2.
+         apply (IlistPerm3_cons _ _ i1 i2).
+         * assumption.
+         * apply IH.
+           -- evalLgtiExtro.
+              apply H.
+           -- assert (H4 := extroduce_imap f1 l1 i1).
+              assert (H5 := extroduce_imap f2 l2 i2).
+              apply (IlistPerm3_ilist_rel_eq H4), (IlistPerm3_ilist_rel_eq_snd H5), H3.
    Qed.
 
   Lemma IlistPerm3_exists_rec: forall (T: Set)(RelT: relation T)
@@ -843,79 +841,76 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT l1 l2 H.
      induction H as [l1 l2 _ e2 | l1 l2 i1 i2 h2 H IH].
-     (* empty list *)
-     intros i1.
-     apply False_rec.
-     rewrite e2 in i1.
-     inversion i1.
-     (* non-empty list *)
-     assert (h1:= eq_S _ _ (IlistPerm3_lgti H)).
-     do 2 rewrite <- extroduce_lgti in h1.
-
-     destruct l1 as [n l1] ; destruct l2 as [n2 l2];
-     simpl in i1, i2, h1, h2 ;
-     fold (mkilist l1) in *|-*;
-     fold (mkilist l2) in *|-*.
-     revert l2 i2 h2 H IH ; rewrite <- h1 ; intros l2 i2 h2 H IH ; clear n2 h1.
-     change (forall i1', exists i2', RelT (l1 i1') (l2 i2') /\ 
+     - (* empty list *)
+       intros i1.
+       apply False_rec.
+       rewrite e2 in i1.
+       inversion i1.
+     - (* non-empty list *)
+       assert (h1:= eq_S _ _ (IlistPerm3_lgti H)).
+       do 2 rewrite <- extroduce_lgti in h1.
+       destruct l1 as [n l1] ; destruct l2 as [n2 l2];
+       cbn in i1, i2, h1, h2 ;
+       fold (mkilist l1) in *|-*;
+       fold (mkilist l2) in *|-*.
+       revert l2 i2 h2 H IH ; rewrite <- h1 ; intros l2 i2 h2 H IH ; clear n2 h1.
+       change (forall i1', exists i2', RelT (l1 i1') (l2 i2') /\ 
                          IlistPerm3 RelT (extroduce (mkilist l1) i1') (extroduce (mkilist l2) i2')).
-     intros i1'. 
-     (* is there something to do renaming? *)
-     elim (eq_nat_dec (decode_Fin i1) (decode_Fin i1')) ; intros a.
-     (* f1 = f1' *)
-     rewrite <- (decode_Fin_unique _ _ a).
-     exists i2.
-     split; assumption.
-     (* f1 <> f1' *)
-     destruct n as [|n].
-     (* exclude zero case *)
-     inversion i1.
-     (* main case *)    
-     set (i1'new := index_in_extroduce i1 i1' a).
-     destruct (IH (rewriteFins (extroduce_lgti_S _ i1) i1'new)) as [i2IH [IH1 IH2]].
-     set (i2IH' := rewriteFins (sym_eq (extroduce_lgti_S _ i2)) i2IH).
-     set (i2' := extroduce_Fin i2 i2IH').
-     exists i2'.
-     split.
-     assert (h3: l1 i1' = fcti (extroduce (mkilist l1) i1) (rewriteFins (extroduce_lgti_S l1 i1) i1'new)) by
-       apply index_in_extroduce_ok_cor.
-     assert (h4: l2 i2' = fcti (extroduce (mkilist l2) i2) i2IH).
-     unfold i2', i2IH'.
-     rewrite extroduce_Fin_ok_cor.
-     f_equal.
-     treatFinPure.
-     rewrite h3, h4.
-     assumption.
-     
-     set (i1new := index_in_extroduce i1' i1 (not_eq_sym a)).
-     assert (a2:  decode_Fin i2' <> decode_Fin i2).
-     unfold i2'.
-     intro Hyp.
-     apply decode_Fin_unique in Hyp.
-     apply (extroduce_Fin_not_fex _ Hyp).
-     set (i2new := index_in_extroduce i2' i2 a2).
-     apply (IlistPerm3_cons _ _ (rewriteFins (extroduce_lgti_S l1 i1') i1new) 
-                                (rewriteFins (extroduce_lgti_S l2 i2') i2new)).
-     unfold i1new.
-     rewrite <- index_in_extroduce_ok_cor.
-     unfold i2new.
-     rewrite <- index_in_extroduce_ok_cor.
-     exact h2.
-
-     assert (H1:= extroduce_interchange_eq l1 i1' i1 (not_eq_sym a) a).
-     fold i1new i1'new in H1.
-     assert (H2:= extroduce_interchange_eq l2 i2' i2 a2 (not_eq_sym a2)).
-     fold i2new in H2.
-     apply ilist_rel_sym in H1 ; apply ilist_rel_sym in H2 ; try apply eq_equivalence.
-     apply (IlistPerm3_ilist_rel_eq H1), (IlistPerm3_ilist_rel_eq_snd H2).
-     assert (H3 : i2IH = rewriteFins (extroduce_lgti_S l2 i2) (index_in_extroduce i2 i2' (not_eq_sym a2))).
-     unfold i2', i2IH'.
-     rewrite index_in_from_extroduce.
-     apply decode_Fin_unique.
-     do 2 rewrite <- decode_Fin_match'.
-     reflexivity.
-     rewrite <- H3.
-     assumption.
+       intros i1'. 
+       (* is there something to do renaming? *)
+       elim (eq_nat_dec (decode_Fin i1) (decode_Fin i1')) ; intros a.
+       + (* f1 = f1' *)
+         rewrite <- (decode_Fin_unique _ _ a).
+         exists i2.
+         split; assumption.
+       + (* f1 <> f1' *)
+         destruct n as [|n].
+         * (* exclude zero case *)
+           inversion i1.
+     * (* main case *)    
+       set (i1'new := index_in_extroduce i1 i1' a).
+       destruct (IH (rewriteFins (extroduce_lgti_S _ i1) i1'new)) as [i2IH [IH1 IH2]].
+       set (i2IH' := rewriteFins (sym_eq (extroduce_lgti_S _ i2)) i2IH).
+       set (i2' := extroduce_Fin i2 i2IH').
+       exists i2'.
+       split.
+       -- assert (h3: l1 i1' = fcti (extroduce (mkilist l1) i1) (rewriteFins (extroduce_lgti_S l1 i1) i1'new)) by
+             apply index_in_extroduce_ok_cor.
+          assert (h4: l2 i2' = fcti (extroduce (mkilist l2) i2) i2IH).
+          { unfold i2', i2IH'.
+            rewrite extroduce_Fin_ok_cor.
+            f_equal.
+            treatFinPure. }
+          rewrite h3, h4.
+          assumption.
+       -- set (i1new := index_in_extroduce i1' i1 (not_eq_sym a)).
+          assert (a2:  decode_Fin i2' <> decode_Fin i2).
+          { unfold i2'.
+            intro Hyp.
+            apply decode_Fin_unique in Hyp.
+            apply (extroduce_Fin_not_fex _ Hyp). }
+          set (i2new := index_in_extroduce i2' i2 a2).
+          apply (IlistPerm3_cons _ _ (rewriteFins (extroduce_lgti_S l1 i1') i1new) 
+                                         (rewriteFins (extroduce_lgti_S l2 i2') i2new)).
+          ++ unfold i1new.
+             rewrite <- index_in_extroduce_ok_cor.
+             unfold i2new.
+             rewrite <- index_in_extroduce_ok_cor.
+             exact h2.
+          ++ assert (H1:= extroduce_interchange_eq l1 i1' i1 (not_eq_sym a) a).
+             fold i1new i1'new in H1.
+             assert (H2:= extroduce_interchange_eq l2 i2' i2 a2 (not_eq_sym a2)).
+             fold i2new in H2.
+             apply ilist_rel_sym in H1 ; apply ilist_rel_sym in H2 ; try apply eq_equivalence.
+             apply (IlistPerm3_ilist_rel_eq H1), (IlistPerm3_ilist_rel_eq_snd H2).
+             assert (H3 : i2IH = rewriteFins (extroduce_lgti_S l2 i2) (index_in_extroduce i2 i2' (not_eq_sym a2))).
+             { unfold i2', i2IH'.
+               rewrite index_in_from_extroduce.
+               apply decode_Fin_unique.
+               do 2 rewrite <- decode_Fin_match'.
+               reflexivity. }
+             rewrite <- H3.
+             assumption.
    Qed.
 
    (* from the Coq tutorial at POPL'08 *)
@@ -929,22 +924,21 @@ Section IlistPerm_ind.
    Proof.
      intros T RelT l1 l2 H.
      remember (lgti l1) as n in |-.
-     revert l1 l2 H Heqn ; induction n as [|n IH]; intros l1 l2 H Heqn ; simpl in *|-*.
-     apply IlistPerm4nil_gen.
-     apply (IlistPerm3_lgti H).
-     symmetry; assumption.
-
-     apply is_IlistPerm4.
-     apply (IlistPerm3_lgti H).
-     intro i1.
-     destruct (IlistPerm3_exists_rec H i1) as [i2 [Hyp1 Hyp2]].
-     exists i2.
-     split.
-     exact Hyp1.
-     apply IH.
-     apply Hyp2.
-     evalLgtiExtro.
-     apply Heqn.
+     revert l1 l2 H Heqn ; induction n as [|n IH]; intros l1 l2 H Heqn ; cbn in *|-*.
+     - apply IlistPerm4nil_gen.
+       + apply (IlistPerm3_lgti H).
+       + symmetry; assumption.
+     - apply is_IlistPerm4.
+       + apply (IlistPerm3_lgti H).
+       + intro i1.
+         destruct (IlistPerm3_exists_rec H i1) as [i2 [Hyp1 Hyp2]].
+         exists i2.
+         split.
+         * exact Hyp1.
+         * apply IH.
+           -- apply Hyp2.
+           -- evalLgtiExtro.
+              apply Heqn.
    Qed.
 
    Lemma IlistPerm3_extroduce : forall (T: Set)(RelT: relation T)
@@ -1025,15 +1019,15 @@ Section IlistPerm_ind.
      intros l3 Hyp.
      inversion_clear Hyp as [x y H2 H3].
      apply is_IlistPerm4.
-     transitivity (lgti l2); assumption.
-     intro i1.
-     destruct (IH i1) as [i2 [HypR1 [_ H5]]].
-     destruct (H3 i2) as [i3 [HypR2 H2']].
-     exists i3.
-     split.
-     exists (fcti l2 i2).
-     split; assumption.
-     apply H5, H2'.
+     - transitivity (lgti l2); assumption.
+     - intro i1.
+       destruct (IH i1) as [i2 [HypR1 [_ H5]]].
+       destruct (H3 i2) as [i3 [HypR2 H2']].
+       exists i3.
+       split.
+       + exists (fcti l2 i2).
+         split; assumption.
+       + apply H5, H2'.
    Qed.
  
    Corollary IlistPerm3_trans_special (A: Set)(R1 R2: relation A)(i1 i2 i3: ilist A):
@@ -1051,11 +1045,11 @@ Section IlistPerm_ind.
    Proof.
      intros.
      induction H0.
-     apply IlistPerm3_nil; assumption.
-     apply (IlistPerm3_cons _ _ f1 f2).
-     apply H.
-     assumption.
-     assumption.
+     - apply IlistPerm3_nil; assumption.
+     - apply (IlistPerm3_cons _ _ f1 f2).
+       + apply H.
+         assumption.
+       + assumption.
    Qed.
 
   Section IlistPerm34_dec.
@@ -1075,9 +1069,9 @@ Section IlistPerm_ind.
         fix Hr 5.
         intros H1 H2 l1 l2 H3.
         destruct H3 as [H3 H4 | [i1 [i2 [H3 H4]]]].
-        apply H1 ; assumption.
-        apply (H2 l1 l2 i1 i2 H3 H4).
-        apply Hr ; try assumption.
+        - apply H1 ; assumption.
+        - apply (H2 l1 l2 i1 i2 H3 H4).
+          apply Hr ; try assumption.
       Qed.
 
       Lemma IlistPerm6_lgti (T: Set)(RelT: relation T)(l1 l2: ilist T): IlistPerm6 RelT l1 l2 -> 
@@ -1086,20 +1080,20 @@ Section IlistPerm_ind.
         revert l1 l2.
         fix Hr 3.
         intros l1 l2 [H1 H2 | [i1 [i2 [H1 H2]]]].
-        assumption.
-        assert (H3 := Hr _ _ H2).
-        apply eq_S in H3.
-        do 2 rewrite <- extroduce_lgti in H3.
-        assumption.
+        - assumption.
+        - assert (H3 := Hr _ _ H2).
+          apply eq_S in H3.
+          do 2 rewrite <- extroduce_lgti in H3.
+          assumption.
       Qed.
 
       Lemma IlistPerm3_IlistPerm6_eq (T: Set)(RelT: relation T)(l1 l2: ilist T): 
         IlistPerm3 RelT l1 l2 -> IlistPerm6 RelT l1 l2.
       Proof.
         intros H ; induction H as [l1 l2 H1 H2 | l1 l2 i1 i2 H1 H2 IH].
-        apply IlistPerm6_nil; assumption.
-        apply IlistPerm6_cons.
-        exists i1, i2 ; split; assumption.
+        - apply IlistPerm6_nil; assumption.
+        - apply IlistPerm6_cons.
+          exists i1, i2 ; split; assumption.
       Qed.
 
       Lemma IlistPerm6_IlistPerm3_eq (T: Set)(RelT: relation T)(l1 l2: ilist T): 
@@ -1107,8 +1101,8 @@ Section IlistPerm_ind.
       Proof.
         intros H.
         induction H using IlistPerm6_ind_better.
-        apply IlistPerm3_nil ; assumption.
-        apply (IlistPerm3_cons _ _ i1 i2); assumption.
+        - apply IlistPerm3_nil ; assumption.
+        - apply (IlistPerm3_cons _ _ i1 i2); assumption.
       Qed.
 
       Lemma IlistPerm4_IlistPerm6_eq (T: Set)(RelT: relation T)(l1 l2: ilist T): 
@@ -1135,16 +1129,15 @@ Section IlistPerm_ind.
       intros i1 i2 H.
       apply IlistPerm4_IlistPerm6_eq in H.
       induction H  as [l1 l2 H1 H2| l1 l2 i1' i2' H1 H2 IH] using IlistPerm6_ind_better.
-      apply False_rec; rewrite H2 in i1 ; inversion i1.
+      { apply False_rec; rewrite H2 in i1 ; inversion i1. }
       destruct l1 as [n l1] ; destruct l2 as [n2 l2] ; assert (H4 := IlistPerm6_lgti H2) ; 
-      simpl in H1, i1', i2'; fold (mkilist l1) (mkilist l2) in *|-*.
-      apply eq_S in H4 ; do 2 rewrite <- extroduce_lgti in H4 ; simpl in H4.
+      cbn in H1, i1', i2'; fold (mkilist l1) (mkilist l2) in *|-*.
+      apply eq_S in H4 ; do 2 rewrite <- extroduce_lgti in H4 ; cbn in H4.
       revert l2 i2' H1 H2 IH i2; rewrite <- H4 ; clear n2 H4 ; intros l2 i2' H1 H2 IH i2 H3 ; 
-      simpl in i1, i2, H3.
+      cbn in i1, i2, H3.
       destruct n as [|n].
-      inversion i1.
+      { inversion i1. }
       apply IlistPerm6_IlistPerm4_eq.
-      
       elim (eq_nat_dec (decode_Fin i1') (decode_Fin i1)) ; intros a ; 
       (* case i1 = i1'*) 
       try (revert H3 ; rewrite <- (decode_Fin_unique _ _ a) ; clear i1 a; intros H3) ; 
@@ -1155,40 +1148,37 @@ Section IlistPerm_ind.
       try apply H2 ; 
       (* all other cases *)
       apply IlistPerm6_cons ; apply IlistPerm6_IlistPerm4_eq in H2.
-      
-      (* case i1 = i1' /\ i2 <> i2' *)
-      apply IlistPerm4_sym_IlistPerm5, (IlistPerm5_sym Req) in H2; try (destruct Req ; assumption).
-      inversion_clear H2 as [i3 i4 H9 H4 H10 H11] ; clear H9.
-      destruct (H4 (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce i2' i2 b))) as [i1 [H5 H6]].
-      exists i1, (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce i2 i2' (not_eq_sym b))).
-      split.
-      rewrite H5, <- index_in_extroduce_ok_cor, <- index_in_extroduce_ok_cor, <- H3.
-      assumption.
-      apply IlistPerm3_IlistPerm6_eq, (IlistPerm3_ilist_rel_eq_snd (extroduce_interchange_eq l2 _ _ b _)).
-      apply IlistPerm5_IlistPerm3_eq, H6.
-      
-      (* cas i1 <> i1' /\ i2 = i2' *)
-      inversion_clear H2 as [i3 i4 H9 H4 H10 H11] ; clear H9.
-      destruct (H4 (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce i1' i1 a))) as [i2 [H5 H6]].
-      exists (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce i1 i1' (not_eq_sym a))), i2.
-      split.
-      rewrite <- H5, <- index_in_extroduce_ok_cor, <- index_in_extroduce_ok_cor, H3.
-      assumption.
-      apply IlistPerm3_IlistPerm6_eq, 
-      (IlistPerm3_ilist_rel_eq (extroduce_interchange_eq l1 _ _ a (not_eq_sym a))).
-      apply IlistPerm4_IlistPerm3_eq, H6.
-      
-      (* cas i1 <> i1' /\ i2 <> i2' *) 
-      exists (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce _ _ (not_eq_sym a))), 
+      - (* case i1 = i1' /\ i2 <> i2' *)
+        apply IlistPerm4_sym_IlistPerm5, (IlistPerm5_sym Req) in H2; try (destruct Req ; assumption).
+        inversion_clear H2 as [i3 i4 H9 H4 H10 H11] ; clear H9.
+        destruct (H4 (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce i2' i2 b))) as [i1 [H5 H6]].
+        exists i1, (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce i2 i2' (not_eq_sym b))).
+        split.
+        + rewrite H5, <- index_in_extroduce_ok_cor, <- index_in_extroduce_ok_cor, <- H3.
+          assumption.
+        + apply IlistPerm3_IlistPerm6_eq, (IlistPerm3_ilist_rel_eq_snd (extroduce_interchange_eq l2 _ _ b _)).
+          apply IlistPerm5_IlistPerm3_eq, H6.
+      - (* cas i1 <> i1' /\ i2 = i2' *)
+        inversion_clear H2 as [i3 i4 H9 H4 H10 H11] ; clear H9.
+        destruct (H4 (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce i1' i1 a))) as [i2 [H5 H6]].
+        exists (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce i1 i1' (not_eq_sym a))), i2.
+        split.
+        + rewrite <- H5, <- index_in_extroduce_ok_cor, <- index_in_extroduce_ok_cor, H3.
+          assumption.
+        + apply IlistPerm3_IlistPerm6_eq, 
+          (IlistPerm3_ilist_rel_eq (extroduce_interchange_eq l1 _ _ a (not_eq_sym a))).
+          apply IlistPerm4_IlistPerm3_eq, H6.
+      - (* cas i1 <> i1' /\ i2 <> i2' *) 
+        exists (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce _ _ (not_eq_sym a))), 
       (rewriteFins (extroduce_lgti_S _ _) (index_in_extroduce _ _ (not_eq_sym b))).
-      split.
-      do 2 rewrite <- index_in_extroduce_ok_cor.
-      assumption.
-      apply IlistPerm3_IlistPerm6_eq, (IlistPerm3_ilist_rel_eq (extroduce_interchange_eq l1 _ _ a _)).
-      apply (IlistPerm3_ilist_rel_eq_snd (extroduce_interchange_eq l2 _ _ b _)), IlistPerm4_IlistPerm3_eq.
-      apply IH.
-      do 2 rewrite <- index_in_extroduce_ok_cor.
-      assumption.
+        split.
+        + do 2 rewrite <- index_in_extroduce_ok_cor.
+          assumption.
+        + apply IlistPerm3_IlistPerm6_eq, (IlistPerm3_ilist_rel_eq (extroduce_interchange_eq l1 _ _ a _)).
+          apply (IlistPerm3_ilist_rel_eq_snd (extroduce_interchange_eq l2 _ _ b _)), IlistPerm4_IlistPerm3_eq.
+          apply IH.
+          do 2 rewrite <- index_in_extroduce_ok_cor.
+          assumption.
     Qed.
 
     Lemma exists_eq_Ilist (T: Set)(RelT: relation T)
@@ -1196,27 +1186,24 @@ Section IlistPerm_ind.
       { i | RelT t (l i)} + {not (exists i, RelT t (l i))}.
     Proof.
       induction n as [|n IH].
-      right.
-      intros [i _] ; inversion i.
-      
-      elim (Rdec t (l (first n))) ; intros H.
-      left.
-      exists (first n) ; assumption.
-      
-      destruct (IH (fun x => l (succ x))) as [[i H1] | H1].
-      left.
-      exists (succ i) ; assumption.
-      right.
-      
-      intros [i H2].
-      elim (zerop (decode_Fin i)) ; intros a.
-      rewrite (decode_Fin_0_first _ a) in H2.
-      contradiction.
-      apply H1.
-      exists (get_cons _ a).
-      rewrite <- (decode_Fin_unique _ _ (decode_Fin_get_cons _ _ : 
-        decode_Fin i = decode_Fin (succ (get_cons i a)))).
-      assumption.
+      - right.
+        intros [i _] ; inversion i.
+      - elim (Rdec t (l (first n))) ; intros H.
+        + left.
+          exists (first n) ; assumption.
+        + destruct (IH (fun x => l (succ x))) as [[i H1] | H1].
+          * left.
+            exists (succ i) ; assumption.
+          * right.
+            intros [i H2].
+            elim (zerop (decode_Fin i)) ; intros a.
+            -- rewrite (decode_Fin_0_first _ a) in H2.
+               contradiction.
+            -- apply H1.
+               exists (get_cons _ a).
+               rewrite <- (decode_Fin_unique _ _ (decode_Fin_get_cons _ _ : 
+                   decode_Fin i = decode_Fin (succ (get_cons i a)))).
+               assumption.
     Qed.
     
     Lemma IlistPerm4_dec (T: Set)(RelT: relation T)(Req : Equivalence RelT)
@@ -1226,63 +1213,55 @@ Section IlistPerm_ind.
       intros [n1 l1] [n2 l2].
       (* comparison between n1 and n2 *)
       elim (eq_nat_dec n1 n2) ; intros H.
-      (* case n1 = n2 --> suppression of n2 *)
-      revert l2.
-      rewrite <- H.
-      intros l2 ; clear n2 H.
-      
-      (* induction on n1 *)
-      induction n1 as [|n1 IH].
-      
-      (* case 0 *)
-      left.
-      apply IlistPerm4nil.
-      
-      (* case S n1 *)
-      (* Does an element in l2 "equal" to l1 (first n1) exists ? *)
-      elim (exists_eq_Ilist RelT Rdec (l1 (first n1)) l2) ; intros H1.
-      
-      (* yes : i *)
-      destruct H1 as [i H1].
-      (* trick to use IH *)
-      set (e1 := extroduce (mkilist l1) (first n1)).
-      set (e2 := extroduce (mkilist l2) i).
-      assert (H2 : n1 = lgti e1) by apply extroduce_lgti_S.
-      assert (H3 : n1 = lgti e2) by apply extroduce_lgti_S.
-      assert (H4 := refl_equal _ : e1 = extroduce (mkilist l1) (first n1)).
-      assert (H5 := refl_equal _ : e2 = extroduce (mkilist l2) i).
-      destruct e1 as [n1' e1] ; destruct e2 as [n2' e2] ; simpl in H2, H3.
-      revert e1 e2 H4 H5 ; rewrite <- H2, <- H3 ; clear n1' n2' H2 H3 ; intros e1 e2 H2 H3.
-      elim (IH e1 e2) ; clear IH ; intros H4 ; 
-      rewrite H2, H3 in H4 ; clear e1 e2 H2 H3.
-      
-      (* here we prove the ilists are equivalent *)
-      left.
-      apply IlistPerm3_IlistPerm4_eq.
-      apply (IlistPerm3_cons _ _ (first n1 : Fin (lgti (mkilist l1))) (i : Fin (lgti (mkilist l2))) H1).
-      apply (IlistPerm4_IlistPerm3_eq H4).
-      
-      (* here we prove the ilists are not equivalent *)
-      right.
-      intros H5.
-      assert (H6 := extroduce_IlistPerm4 _ (first n1: Fin (lgti (mkilist l1))) 
-        (i: Fin (lgti (mkilist l2))) H5 H1).
-      contradiction.
-      
-      (* no *)
-      right.
-      intro H.
-      inversion H.
-      clear H0 H3 H4 i1 i2.
-      destruct (H2 (first n1)) as [i [H3 _]].
-      apply H1.
-      exists i ; assumption.
-      
-      (* cas n1 <> n2 *)
-      right.
-      intro H1.
-      apply IlistPerm4_lgti in H1.
-      contradiction.
+      - (* case n1 = n2 --> suppression of n2 *)
+        revert l2.
+        rewrite <- H.
+        intros l2 ; clear n2 H.
+        (* induction on n1 *)
+        induction n1 as [|n1 IH].
+        + (* case 0 *)
+          left.
+          apply IlistPerm4nil.
+        + (* case S n1 *)
+          (* Does an element in l2 "equal" to l1 (first n1) exists ? *)
+          elim (exists_eq_Ilist RelT Rdec (l1 (first n1)) l2) ; intros H1.
+          * (* yes : i *)
+            destruct H1 as [i H1].
+            (* trick to use IH *)
+            set (e1 := extroduce (mkilist l1) (first n1)).
+            set (e2 := extroduce (mkilist l2) i).
+            assert (H2 : n1 = lgti e1) by apply extroduce_lgti_S.
+            assert (H3 : n1 = lgti e2) by apply extroduce_lgti_S.
+            assert (H4 := refl_equal _ : e1 = extroduce (mkilist l1) (first n1)).
+            assert (H5 := refl_equal _ : e2 = extroduce (mkilist l2) i).
+            destruct e1 as [n1' e1] ; destruct e2 as [n2' e2] ; cbn in H2, H3.
+            revert e1 e2 H4 H5 ; rewrite <- H2, <- H3 ; clear n1' n2' H2 H3 ; intros e1 e2 H2 H3.
+            elim (IH e1 e2) ; clear IH ; intros H4 ; 
+              rewrite H2, H3 in H4 ; clear e1 e2 H2 H3.
+            -- (* here we prove the ilists are equivalent *)
+              left.
+              apply IlistPerm3_IlistPerm4_eq.
+              apply (IlistPerm3_cons _ _ (first n1 : Fin (lgti (mkilist l1))) (i : Fin (lgti (mkilist l2))) H1).
+              apply (IlistPerm4_IlistPerm3_eq H4).
+            -- (* here we prove the ilists are not equivalent *)
+              right.
+              intros H5.
+              assert (H6 := extroduce_IlistPerm4 _ (first n1: Fin (lgti (mkilist l1))) 
+                 (i: Fin (lgti (mkilist l2))) H5 H1).
+              contradiction.
+          * (* no *)
+            right.
+            intro H.
+            inversion H.
+            clear H0 H3 H4 i1 i2.
+            destruct (H2 (first n1)) as [i [H3 _]].
+            apply H1.
+            exists i ; assumption.
+      - (* cas n1 <> n2 *)
+        right.
+        intro H1.
+        apply IlistPerm4_lgti in H1.
+        contradiction.
     Qed.
       
     Lemma IlistPerm4_dec_IlistPerm3_dec (T: Set)(RelT: relation T):
@@ -1291,8 +1270,8 @@ Section IlistPerm_ind.
     Proof.
       intros H l1 l2.
       destruct (H l1 l2) as [H1 | H1].
-      left ; apply IlistPerm4_IlistPerm3_eq, H1.
-      right ; intro H2 ; apply H1, IlistPerm3_IlistPerm4_eq, H2.
+      - left ; apply IlistPerm4_IlistPerm3_eq, H1.
+      - right ; intro H2 ; apply H1, IlistPerm3_IlistPerm4_eq, H2.
     Qed.
   
     Lemma IlistPerm3_dec (T: Set)(RelT: relation T)(Req : Equivalence RelT)
@@ -1324,23 +1303,23 @@ Section IlistPerm_ind.
       IlistPerm3Cert_list n2.
     Proof.
       revert n2 H ; induction n1 as [|n1 IH] ; intros [|n2] H.
-      exact tt.
-      inversion H.
-      inversion H.
-      destruct f as [[i1 i2] f].
-      fold (IlistPerm3Cert_list n1) in f.
-      split.
-      exact (rewriteFins H i1, rewriteFins H i2).
-      apply (IH f).
-      apply eq_add_S, H.
+      - exact tt.
+      - inversion H.
+      - inversion H.
+      - destruct f as [[i1 i2] f].
+        fold (IlistPerm3Cert_list n1) in f.
+        split.
+        + exact (rewriteFins H i1, rewriteFins H i2).
+        + apply (IH f).
+          apply eq_add_S, H.
     Defined.
 
     Definition IlistPerm3Cert_aux3 (A: Set)(l1 l2: ilist A)(Hyp : lgti l1 = lgti l2)(i1: Fin(lgti l1))
       (i2 : Fin (lgti l2))(c: IlistPerm3Cert_list (lgti (extroduce l1 i1))): IlistPerm3Cert_list (lgti l1).
     Proof.
       destruct l1 as [[|n1] l1].
-      inversion i1.
-      exact (i1, (rewriteFins (sym_eq Hyp) i2), (rewriteIlistPerm3Cert_list (sym_eq (extroduce_lgti_S _ _)) c)).
+      - inversion i1.
+      - exact (i1, (rewriteFins (sym_eq Hyp) i2), (rewriteIlistPerm3Cert_list (sym_eq (extroduce_lgti_S _ _)) c)).
     Defined.
 
     Lemma IlistPerm3Cert_list_eq (n: nat)(c: IlistPerm3Cert_list n)(H: n = n) : 
@@ -1348,7 +1327,7 @@ Section IlistPerm_ind.
     Proof.
       induction n as [|n IH]. 
       - destruct c; reflexivity.
-      - destruct c as [[i1 i2] c]. simpl.
+      - destruct c as [[i1 i2] c]. cbn.
         f_equal ; try f_equal ; try treatFinPure.
         apply IH.
     Qed.
@@ -1357,30 +1336,30 @@ Section IlistPerm_ind.
       (f: IlistPerm3Cert_list n1), rewriteIlistPerm3Cert_list e1 f = rewriteIlistPerm3Cert_list e2 f.
     Proof.
       induction n1 as [|n1 IH]; intros [|n2] e1 e2 f.
-      reflexivity.
-      inversion e1.
-      inversion e1.
-      destruct f as [[i1 i2] f].
-      simpl.
-      f_equal.
-      f_equal ; treatFinPure.
-      apply IH.
+      - reflexivity.
+      - inversion e1.
+      - inversion e1.
+      - destruct f as [[i1 i2] f].
+        cbn.
+        f_equal.
+        f_equal ; treatFinPure.
+        apply IH.
     Qed.
     
     Lemma rewriteIlistPerm3Cert_list_sym: forall (n1 n2: nat)(e: n1 = n2)(f: IlistPerm3Cert_list n2),
       rewriteIlistPerm3Cert_list e (rewriteIlistPerm3Cert_list (sym_eq e) f) = f.
     Proof.
       induction n1 as [|n1 IH]; intros [|n2] e f.
-      destruct f.
-      reflexivity.
-      inversion e.
-      inversion e.
-      destruct f as [[i1 i2] f].
-      simpl.
-      f_equal.
-      f_equal ; treatFinPure.
-      rewrite (rewriteIlistPerm3Cert_list_proofirr _ (eq_sym (eq_add_S _ _ e))).
-      apply IH.
+      - destruct f.
+        reflexivity.
+      - inversion e.
+      - inversion e.
+      - destruct f as [[i1 i2] f].
+        simpl.
+        f_equal.
+        f_equal ; treatFinPure.
+        rewrite (rewriteIlistPerm3Cert_list_proofirr _ (eq_sym (eq_add_S _ _ e))).
+        apply IH.
     Qed.
 
     Lemma IlistPerm3Cert_aux3_ok1(A: Set)(n: nat)(l1 l2: ilistn A (S n))(Hyp : lgti (mkilist l1) = lgti (mkilist l2))
@@ -1389,7 +1368,7 @@ Section IlistPerm_ind.
       IlistPerm3Cert_aux3 (mkilist l1) (mkilist l2) Hyp i1 i2 c = 
       (((i1, i2: Fin (lgti (mkilist l1))), rewriteIlistPerm3Cert_list (sym_eq (extroduce_lgti_S l1 i1)) c)).
     Proof.
-      simpl.
+      cbn.
       repeat f_equal.
       apply decode_Fin_unique, sym_eq, decode_Fin_match.
     Qed.
@@ -1399,13 +1378,13 @@ Section IlistPerm_ind.
       IlistPerm3Cert_aux3 l1 l2 H1 i1 i2 c = IlistPerm3Cert_aux3 l1 l2 H2 i1 i2 c.
     Proof.
       destruct l1 as [n1 l1] ; destruct l2 as [n2 l2].
-      simpl in H1, H2, i1, i2.
+      cbn in H1, H2, i1, i2.
       revert l2 H2 i2 c ; rewrite <- H1 ; clear n2 H1 ; intros l2 H2 i2 c.
       destruct n1 as [|n1].
-      inversion i1.
-      simpl.
-      do 2 f_equal.
-      treatFinPure.
+      - inversion i1.
+      - cbn.
+        do 2 f_equal.
+        treatFinPure.
     Qed.
 
     Inductive IlistPerm3Cert (A: Set)(RA: relation A)(l1 l2: ilist A)(Hyp: lgti l1 = lgti l2)
@@ -1423,8 +1402,8 @@ Section IlistPerm_ind.
     Proof.
       intro H.
       induction H.
-      apply IlistPerm3_nil; assumption.
-      apply (IlistPerm3_cons _ _ i1 i2); assumption.
+      - apply IlistPerm3_nil; assumption.
+      - apply (IlistPerm3_cons _ _ i1 i2); assumption.
     Qed.
 
     Lemma IlistPerm3_IlistPerm3Cert (A: Set)(RA: relation A)(i1 i2: ilist A)(Hyp: lgti i1 = lgti i2): 
@@ -1432,12 +1411,12 @@ Section IlistPerm_ind.
     Proof.
       intro H.
       induction H as [l1 l2 H1 H2 |l1 l2 i1 i2 H1 H2 IH ].
-      exists (rewriteIlistPerm3Cert_list (sym_eq H2) tt).
-      apply IlistPerm3Cert_nil.
-      assumption.
-      destruct (IH (IlistPerm3Cert_aux2 l1 l2 Hyp i1 i2)) as [c Hypf].
-      exists (IlistPerm3Cert_aux3 l1 l2 Hyp i1 i2 c).
-      apply (@IlistPerm3Cert_cons _ _ _ _  _ _  _ i2 c H1 (refl_equal _) Hypf).
+      - exists (rewriteIlistPerm3Cert_list (sym_eq H2) tt).
+        apply IlistPerm3Cert_nil.
+        assumption.
+      - destruct (IH (IlistPerm3Cert_aux2 l1 l2 Hyp i1 i2)) as [c Hypf].
+        exists (IlistPerm3Cert_aux3 l1 l2 Hyp i1 i2 c).
+        apply (@IlistPerm3Cert_cons _ _ _ _  _ _  _ i2 c H1 (refl_equal _) Hypf).
     Qed.
 
     Lemma IlistPerm3Cert_mon (A: Set)(RA1 RA2: relation A)(HypR: subrelation RA1 RA2)(i1 i2: ilist A)
@@ -1446,9 +1425,9 @@ Section IlistPerm_ind.
     Proof.
       intro H.
       induction H.
-      apply IlistPerm3Cert_nil, H.
-      apply (@IlistPerm3Cert_cons _ _ _ _ _ _ _ i2 c') ; try assumption.
-      apply HypR, H.
+      - apply IlistPerm3Cert_nil, H.
+      - apply (@IlistPerm3Cert_cons _ _ _ _ _ _ _ i2 c') ; try assumption.
+        apply HypR, H.
     Qed.
 
     Lemma IlistPerm3Cert_proofirr(T: Set)(R: relation T)(l1 l2: ilist T)(H1 H2: lgti l1 = lgti l2)
@@ -1456,11 +1435,11 @@ Section IlistPerm_ind.
     Proof.
       intros H3.
       induction H3 as [l1 l2 H1 c H3 |l1 l2 H1 c i1 i2 c' H3 H4 _ IH].
-      apply IlistPerm3Cert_nil, H3.
-      apply (@IlistPerm3Cert_cons _ _ _ _ _ _ i1 i2 c' H3).
-      rewrite H4.
-      apply IlistPerm3Cert_aux3_proofirr.
-      apply IH.
+      - apply IlistPerm3Cert_nil, H3.
+      - apply (@IlistPerm3Cert_cons _ _ _ _ _ _ i1 i2 c' H3).
+        + rewrite H4.
+          apply IlistPerm3Cert_aux3_proofirr.
+        + apply IH.
     Qed.
 
     Lemma IlistPerm3Cert_inter (A: Set)(l1 l2: ilist A)(Hyp: lgti l1 = lgti l2)
@@ -1469,81 +1448,78 @@ Section IlistPerm_ind.
       IlistPerm3Cert (fun a1 a2 => forall i, R i a1 a2) l1 l2 Hyp c.
     Proof.
       destruct l1 as [n1 l1] ; destruct l2 as [n2 l2]. 
-      simpl in Hyp.
+      cbn in Hyp.
       revert l2 c HypR ; rewrite <- Hyp ; intros l2 c H1.
-      simpl in *|-*.
+      cbn in *|-*.
       fold (mkilist l1) (mkilist l2) in *|-*.
       clear Hyp n2.
       induction n1 as [|n1 IH].
-      apply IlistPerm3Cert_nil.
-      reflexivity.
-      
-      destruct c as [[i1 i2] c] ; fold (IlistPerm3Cert_list n1) in c.
-      apply (@IlistPerm3Cert_cons _ _ _ _ _ _ (i1: Fin (lgti (mkilist l1))) 
-      (i2: Fin (lgti (mkilist l2))) (rewriteIlistPerm3Cert_list (extroduce_lgti_S _ _) c)).
-      intros i.
-      destruct (H1 i) as [H | i1' i2' c'' H5 H6 H7].
-      inversion H.
-      simpl in H6.
-      inversion H6.
-      assumption.
-      simpl.
-      rewrite (rewriteIlistPerm3Cert_list_proofirr _ (eq_sym (eq_sym (extroduce_lgti_S l1 i1)))), 
-      rewriteIlistPerm3Cert_list_sym.
-      reflexivity.
-      
-      set (l1' := extroduce (mkilist l1) i1).
-      set (l2' := extroduce (mkilist l2) i2).
-      assert(H4 := extroduce_lgti_S l1 i1 : n1 = lgti l1').
-      rewrite (rewriteIlistPerm3Cert_list_proofirr _ H4).
-      assert (H5 := IlistPerm3Cert_aux2 (mkilist l1) (mkilist l2) (eq_refl (S n1)) i1 i2 : 
-      lgti l1' = lgti l2').
-      apply (@IlistPerm3Cert_proofirr _ _ _ _ H5 _ (rewriteIlistPerm3Cert_list H4 c)).
-      
-      assert (H2 := refl_equal _ : l1' = extroduce (mkilist l1) i1) ;
-      assert (H3 := refl_equal _ : l2' = extroduce (mkilist l2) i2).
-      destruct l1' as [n1' l1'] ; destruct l2' as [n2' l2'].
-      simpl in H4, H5.
-      revert l1' l2' H2 H3 ; rewrite <- H5, <- H4 ; clear n1' n2' H4 H5 ; intros l1' l2' H2 H3.
-      fold (mkilist l1') (mkilist l2') in *|-*.
-      apply IH ; clear IH.
-      rewrite <- IlistPerm3Cert_list_eq.
-      intros i.
-      destruct (H1 i) as [H4 | i1' i2' c'' _ H4 H5].
-      inversion H4.
-      simpl in H4.
-      inversion H4.
-      revert H2 H3 ; rewrite H0, H6 ; intros H2 H3 ; clear i1 i2 H1 H0 H4 H6 H7 c.
-      assert (H6 := eq_sym (extroduce_lgti_S l1 i1')).
-      rewrite (rewriteIlistPerm3Cert_list_proofirr _ H6).
-      assert (H7 := IlistPerm3Cert_aux2 (mkilist l1) (mkilist l2) (eq_refl (S n1)) i1' i2').
-      apply (IlistPerm3Cert_proofirr H7) in H5.
-      revert H5.
-      revert H6 H7 c''.
-      rewrite <- H2, <- H3.
-      simpl.
-      intros H6 H7 c''.
-      rewrite <- IlistPerm3Cert_list_eq.
-      apply IlistPerm3Cert_proofirr.
+      - apply IlistPerm3Cert_nil.
+        reflexivity.
+      - destruct c as [[i1 i2] c] ; fold (IlistPerm3Cert_list n1) in c.
+        apply (@IlistPerm3Cert_cons _ _ _ _ _ _ (i1: Fin (lgti (mkilist l1))) 
+          (i2: Fin (lgti (mkilist l2))) (rewriteIlistPerm3Cert_list (extroduce_lgti_S _ _) c)).
+        + intros i.
+          destruct (H1 i) as [H | i1' i2' c'' H5 H6 H7].
+          * inversion H.
+          * cbn in H6.
+            inversion H6.
+            assumption.
+        + cbn.
+          rewrite (rewriteIlistPerm3Cert_list_proofirr _ (eq_sym (eq_sym (extroduce_lgti_S l1 i1)))), 
+          rewriteIlistPerm3Cert_list_sym.
+          reflexivity.
+        + set (l1' := extroduce (mkilist l1) i1).
+          set (l2' := extroduce (mkilist l2) i2).
+          assert(H4 := extroduce_lgti_S l1 i1 : n1 = lgti l1').
+          rewrite (rewriteIlistPerm3Cert_list_proofirr _ H4).
+          assert (H5 := IlistPerm3Cert_aux2 (mkilist l1) (mkilist l2) (eq_refl (S n1)) i1 i2 : 
+            lgti l1' = lgti l2').
+          apply (@IlistPerm3Cert_proofirr _ _ _ _ H5 _ (rewriteIlistPerm3Cert_list H4 c)).
+          assert (H2 := refl_equal _ : l1' = extroduce (mkilist l1) i1) ;
+            assert (H3 := refl_equal _ : l2' = extroduce (mkilist l2) i2).
+          destruct l1' as [n1' l1'] ; destruct l2' as [n2' l2'].
+          cbn in H4, H5.
+          revert l1' l2' H2 H3 ; rewrite <- H5, <- H4 ; clear n1' n2' H4 H5 ; intros l1' l2' H2 H3.
+          fold (mkilist l1') (mkilist l2') in *|-*.
+          apply IH ; clear IH.
+          rewrite <- IlistPerm3Cert_list_eq.
+          intros i.
+          destruct (H1 i) as [H4 | i1' i2' c'' _ H4 H5].
+          * inversion H4.
+          * cbn in H4.
+            inversion H4.
+            revert H2 H3 ; rewrite H0, H6 ; intros H2 H3 ; clear i1 i2 H1 H0 H4 H6 H7 c.
+            assert (H6 := eq_sym (extroduce_lgti_S l1 i1')).
+            rewrite (rewriteIlistPerm3Cert_list_proofirr _ H6).
+            assert (H7 := IlistPerm3Cert_aux2 (mkilist l1) (mkilist l2) (eq_refl (S n1)) i1' i2').
+            apply (IlistPerm3Cert_proofirr H7) in H5.
+            revert H5.
+            revert H6 H7 c''.
+            rewrite <- H2, <- H3.
+            simpl.
+            intros H6 H7 c''.
+            rewrite <- IlistPerm3Cert_list_eq.
+            apply IlistPerm3Cert_proofirr.
     Qed.
     
     Definition IlistPerm3Cert_list_function (n: nat)(c: IlistPerm3Cert_list n) : Fin n -> Fin n.
     Proof.
       induction n as [|n IH] ; intro i.
-      inversion i.
-      destruct c as [[i1 i2] c].
-      fold (IlistPerm3Cert_list n) in c.
-      elim (eq_nat_dec (decode_Fin i1) (decode_Fin i)); intros a.
-      exact i2.
-      exact (extroduce_Fin i2 (IH c (index_in_extroduce _ _ a))).
+      - inversion i.
+      - destruct c as [[i1 i2] c].
+        fold (IlistPerm3Cert_list n) in c.
+        elim (eq_nat_dec (decode_Fin i1) (decode_Fin i)); intros a.
+        + exact i2.
+        + exact (extroduce_Fin i2 (IH c (index_in_extroduce _ _ a))).
     Defined.
 
     Definition IlistPerm3Cert_list_inv (n: nat)(c: IlistPerm3Cert_list n) : IlistPerm3Cert_list n.
     Proof.
       induction n as [|n IH].
-      apply c.
-      destruct c as [[i1 i2] c].
-      exact ((i2, i1), (IH c)).
+      - apply c.
+      - destruct c as [[i1 i2] c].
+        exact ((i2, i1), (IH c)).
     Defined.
 
     Definition IlistPerm3Cert_list_function_inv (n: nat)(c: IlistPerm3Cert_list n):= 
@@ -1553,10 +1529,10 @@ Section IlistPerm_ind.
       IlistPerm3Cert_list_inv _ (IlistPerm3Cert_list_inv _ c) = c.
     Proof.
       induction n as [|n IH].
-      reflexivity.
-      destruct c as [[i1 i2] c].
-      simpl.
-      rewrite IH ; reflexivity.
+      - reflexivity.
+      - destruct c as [[i1 i2] c].
+        cbn.
+        rewrite IH ; reflexivity.
     Qed.
 
     Lemma IP3Cl_function_ok1 (n: nat)(i1 i2 : Fin (S n))(c: IlistPerm3Cert_list n)(i: Fin (S n)) : 
@@ -1564,11 +1540,11 @@ Section IlistPerm_ind.
     Proof.
       intros H.
       rewrite (decode_Fin_unique _ _ H).
-      simpl.
+      cbn.
       unfold sumbool_rec, sumbool_rect.
       elim (eq_nat_dec (decode_Fin i) (decode_Fin i)) ; intros a.
-      reflexivity.
-      apply False_rec, a, eq_refl.
+      - reflexivity.
+      - apply False_rec, a, eq_refl.
     Qed.
 
     Lemma IP3Cl_function_ok2 (n: nat)(i1 i2 : Fin (S n))(c: IlistPerm3Cert_list n)(i: Fin (S n))
@@ -1578,13 +1554,13 @@ Section IlistPerm_ind.
       succ (IlistPerm3Cert_list_function c (index_in_extroduce _ _ h)).
     Proof.
       intros H.
-      simpl.
+      cbn.
       unfold sumbool_rec, sumbool_rect.
       elim (eq_nat_dec (decode_Fin i1) (decode_Fin i)) ; intros a.
-      contradiction a.
-      rewrite (index_in_extroduce_proofirr _ _ a h).
-      apply extroduce_Fin_ok1.
-      assumption.
+      - contradiction a.
+      - rewrite (index_in_extroduce_proofirr _ _ a h).
+        apply extroduce_Fin_ok1.
+        assumption.
     Qed.
     
     Lemma IP3Cl_function_ok3 (n: nat)(i1 i2 : Fin (S n))(c: IlistPerm3Cert_list n)(i: Fin (S n))
@@ -1594,13 +1570,13 @@ Section IlistPerm_ind.
         weakFin (IlistPerm3Cert_list_function c (index_in_extroduce _ _ h)).
     Proof.
       intros H.
-      simpl.
+      cbn.
       unfold sumbool_rec, sumbool_rect.
       elim (eq_nat_dec (decode_Fin i1) (decode_Fin i)) ; intros a.
-      contradiction a.
-      rewrite (index_in_extroduce_proofirr _ _ a h).
-      apply extroduce_Fin_ok2.
-      assumption.
+      - contradiction a.
+      - rewrite (index_in_extroduce_proofirr _ _ a h).
+        apply extroduce_Fin_ok2.
+        assumption.
     Qed.
 
     Lemma IP3Cl_function_ok4 (n: nat)(i1 i2 : Fin (S n))(c: IlistPerm3Cert_list n)(i: Fin (S n))
@@ -1608,88 +1584,75 @@ Section IlistPerm_ind.
       IlistPerm3Cert_list_function (((i1, i2), c): IlistPerm3Cert_list (S n)) i = 
       extroduce_Fin i2 (IlistPerm3Cert_list_function c (index_in_extroduce _ _ h)).
     Proof.
-      simpl.
+      cbn.
       unfold sumbool_rec, sumbool_rect.
       elim (eq_nat_dec (decode_Fin i1) (decode_Fin i)) ; intros a.
-      contradiction a.
-      rewrite (index_in_extroduce_proofirr _ _ a h).
-      reflexivity.
+      - contradiction a.
+      - rewrite (index_in_extroduce_proofirr _ _ a h).
+        reflexivity.
     Qed.
 
     Lemma IP3Cl_function_function_inv_inv (n: nat)(c: IlistPerm3Cert_list n) : 
       forall i, (IlistPerm3Cert_list_function c) (IlistPerm3Cert_list_function_inv c i) = i.
     Proof.
       intros i ; induction n as [|n IH].
-      inversion i.
-      
+      { inversion i. }      
       destruct c as [[i1 i2] c].
       fold (IlistPerm3Cert_list n) in c.
       unfold IlistPerm3Cert_list_function_inv.
       change (IlistPerm3Cert_list_inv (S n) (i1, i2, c)) with ((i2, i1, (IlistPerm3Cert_list_inv n c))).
-
       elim (eq_nat_dec (decode_Fin i2) (decode_Fin i)) ; intros a.
-      rewrite (IP3Cl_function_ok1 i2 i1 _ i) ; try assumption.
-      rewrite IP3Cl_function_ok1 ; try reflexivity.
-      apply decode_Fin_unique, a.
-      
-      elim (le_lt_dec (decode_Fin i1) 
-      (decode_Fin (IlistPerm3Cert_list_function (IlistPerm3Cert_list_inv n c) (index_in_extroduce i2 i a)))); intros b.
-      rewrite (IP3Cl_function_ok2 _ _ _ _ a b).
-      
-      assert (h : decode_Fin i1 <> (decode_Fin (succ
-      (IlistPerm3Cert_list_function (IlistPerm3Cert_list_inv n c) (index_in_extroduce i2 i a))))).
-      intros h.
-      rewrite h in b.
-      apply (le_Sn_n _ b).
-      
-      apply le_lt_n_Sm in b.
-      change (S (decode_Fin _)) with (decode_Fin (succ  (IlistPerm3Cert_list_function (IlistPerm3Cert_list_inv n c)
+      - rewrite (IP3Cl_function_ok1 i2 i1 _ i) ; try assumption.
+        rewrite IP3Cl_function_ok1 ; try reflexivity.
+        apply decode_Fin_unique, a.
+      - elim (le_lt_dec (decode_Fin i1) 
+        (decode_Fin (IlistPerm3Cert_list_function (IlistPerm3Cert_list_inv n c) (index_in_extroduce i2 i a)))); intros b.
+        + rewrite (IP3Cl_function_ok2 _ _ _ _ a b).
+          assert (h : decode_Fin i1 <> (decode_Fin (succ
+          (IlistPerm3Cert_list_function (IlistPerm3Cert_list_inv n c) (index_in_extroduce i2 i a))))).
+          * intros h.
+            rewrite h in b.
+            apply (le_Sn_n _ b).
+          * apply le_lt_n_Sm in b.
+            change (S (decode_Fin _)) with (decode_Fin (succ  (IlistPerm3Cert_list_function (IlistPerm3Cert_list_inv n c)
         (index_in_extroduce i2 i a)))) in b.
-      fold (IlistPerm3Cert_list_function_inv c) in *|-*.
-      
-
-      elim (le_lt_dec (decode_Fin i2) (decode_Fin (IlistPerm3Cert_list_function c (index_in_extroduce _ _ h)))); 
+            fold (IlistPerm3Cert_list_function_inv c) in *|-*.
+            elim (le_lt_dec (decode_Fin i2) (decode_Fin (IlistPerm3Cert_list_function c (index_in_extroduce _ _ h)))); 
       intros d.
-      rewrite (IP3Cl_function_ok2 _ _ _ _ h) ; try assumption.
-      revert d.
-      rewrite index_in_extroduce_succ2 ; try assumption.
-      rewrite IH.
+            -- rewrite (IP3Cl_function_ok2 _ _ _ _ h) ; try assumption.
+               revert d.
+               rewrite index_in_extroduce_succ2 ; try assumption.
+               rewrite IH.
+               intros d.
+               apply index_in_extroduce_succ ; try assumption.
+            -- rewrite (IP3Cl_function_ok3 _ _ _ _ h) ; try assumption.
+               revert d.
+               rewrite index_in_extroduce_succ2 ; try assumption.
+               rewrite IH.
+               intros d.
+               apply index_in_extroduce_weakFin2 ; try assumption.
+        + rewrite (IP3Cl_function_ok3 _ _ _ _ a b).
+          rewrite <- weakFin_ok in b.
+          assert (h : decode_Fin i1 <> (decode_Fin (weakFin
+            (IlistPerm3Cert_list_function (IlistPerm3Cert_list_inv n c) (index_in_extroduce i2 i a))))).
+          { intros h.
+            rewrite h in b.
+            apply (le_Sn_n _ b). }      
+          fold (IlistPerm3Cert_list_function_inv c) in *|-*.
+          elim (le_lt_dec (decode_Fin i2) (decode_Fin (IlistPerm3Cert_list_function c (index_in_extroduce _ _ h)))); 
       intros d.
-      apply index_in_extroduce_succ ; try assumption.
-      
-      rewrite (IP3Cl_function_ok3 _ _ _ _ h) ; try assumption.
-      revert d.
-      rewrite index_in_extroduce_succ2 ; try assumption.
-      rewrite IH.
-      intros d.
-      apply index_in_extroduce_weakFin2 ; try assumption.
-      
-      rewrite (IP3Cl_function_ok3 _ _ _ _ a b).
-      rewrite <- weakFin_ok in b.
-      
-      assert (h : decode_Fin i1 <> (decode_Fin (weakFin
-      (IlistPerm3Cert_list_function (IlistPerm3Cert_list_inv n c) (index_in_extroduce i2 i a))))).
-      intros h.
-      rewrite h in b.
-      apply (le_Sn_n _ b).
-      
-      fold (IlistPerm3Cert_list_function_inv c) in *|-*.
-      
-      elim (le_lt_dec (decode_Fin i2) (decode_Fin (IlistPerm3Cert_list_function c (index_in_extroduce _ _ h)))); 
-      intros d.
-      rewrite (IP3Cl_function_ok2 _ _ _ _ h) ; try assumption.
-      revert d.
-      rewrite index_in_extroduce_weakFin ; try assumption.
-      rewrite IH.
-      intros d.
-      apply index_in_extroduce_succ ; try assumption.
-      
-      rewrite (IP3Cl_function_ok3 _ _ _ _ h) ; try assumption.
-      revert d.
-      rewrite index_in_extroduce_weakFin ; try assumption.
-      rewrite IH.
-      intros d.
-      apply index_in_extroduce_weakFin2 ; try assumption.
+          * rewrite (IP3Cl_function_ok2 _ _ _ _ h) ; try assumption.
+            revert d.
+            rewrite index_in_extroduce_weakFin ; try assumption.
+            rewrite IH.
+            intros d.
+            apply index_in_extroduce_succ ; try assumption.
+          * rewrite (IP3Cl_function_ok3 _ _ _ _ h) ; try assumption.
+            revert d.
+            rewrite index_in_extroduce_weakFin ; try assumption.
+            rewrite IH.
+            intros d.
+            apply index_in_extroduce_weakFin2 ; try assumption.
     Qed.
 
     Lemma IP3Cl_function_inv_function_inv (n: nat)(c: IlistPerm3Cert_list n) : 
@@ -1707,49 +1670,45 @@ Section IlistPerm_ind.
     Proof.
       intros h1 i.
       induction n as [|n IH].
-      inversion i.
+      {inversion i. }
       destruct h1 as [h1 |i1 i2 c' h1 h2 h3].
-      inversion h1.
-      simpl in i1, i2, h1.
-      rewrite h2.
-      
-      rewrite IlistPerm3Cert_aux3_ok1.
-      
-      elim (eq_nat_dec (decode_Fin i1) (decode_Fin i)) ; intros a.
-      rewrite IP3Cl_function_ok1 ; try assumption.
-      rewrite <- (decode_Fin_unique _ _ a).
-      assumption.
-      
-      rewrite (IP3Cl_function_ok4 _ _ _ _ a).
-      set (i2' := IlistPerm3Cert_list_function (rewriteIlistPerm3Cert_list (eq_sym (extroduce_lgti_S l1 i1)) c') 
-      (index_in_extroduce _ _ a)).
-      change (R (l1 i) (l2 (extroduce_Fin i2 i2'))).
-      
-      assert (h4 : decode_Fin i2 <> decode_Fin (extroduce_Fin i2 i2')).
-      intro H.
-      apply decode_Fin_unique, sym_eq in H.
-      apply (extroduce_Fin_not_fex _ H).
-      rewrite (index_in_extroduce_ok_cor l1 _ _ a), (index_in_extroduce_ok_cor l2 _ _ h4).
-      clear h2.
-      rewrite index_in_from_extroduce.
-      revert c' h3 i2' h4.
-      set (h3' := IlistPerm3Cert_aux2 (mkilist l1) (mkilist l2) h i1 i2).
-      set (h5 := extroduce_lgti_S l1 i1) ; set (h6 := extroduce_lgti_S l2 i2).
-      generalize h3' h5 h6 ; clear h3' h5 h6.
-      set (l1' := extroduce (mkilist l1) i1) ; set (l2' := extroduce (mkilist l2) i2) ;
-      assert (h7 := refl_equal _ : extroduce (mkilist l1) i1 = l1') ; 
-      assert (h8 := refl_equal _ : l2' = extroduce (mkilist l2) i2).
-      destruct l1' as [n1' l1'] ; destruct l2' as [n2' l2'].
-      simpl lgti.
-      intros h3' h5 h6; revert h3' l1' l2' h7 h8.
-      rewrite <- h5, <- h6.
-      clear n1' n2' h5 h6.
-      intros h3' l1' l2' h5 h6 c' h3.
-      fold (mkilist l1') (mkilist l2') in *|-*.
-      rewrite <- IlistPerm3Cert_list_eq.
-      intros i2' h4.
-      do 2 rewrite <- (decode_Fin_unique _ _ (decode_Fin_match' _ _)).
-      apply (IH _ _ _ h3'), h3.
+      - inversion h1.
+      - cbn in i1, i2, h1.
+        rewrite h2.
+        rewrite IlistPerm3Cert_aux3_ok1.
+        elim (eq_nat_dec (decode_Fin i1) (decode_Fin i)) ; intros a.
+        + rewrite IP3Cl_function_ok1 ; try assumption.
+          rewrite <- (decode_Fin_unique _ _ a).
+          assumption.
+        + rewrite (IP3Cl_function_ok4 _ _ _ _ a).
+          set (i2' := IlistPerm3Cert_list_function (rewriteIlistPerm3Cert_list (eq_sym (extroduce_lgti_S l1 i1)) c') 
+            (index_in_extroduce _ _ a)).
+          change (R (l1 i) (l2 (extroduce_Fin i2 i2'))).
+          assert (h4 : decode_Fin i2 <> decode_Fin (extroduce_Fin i2 i2')).
+          { intro H.
+            apply decode_Fin_unique, sym_eq in H.
+            apply (extroduce_Fin_not_fex _ H). }
+          rewrite (index_in_extroduce_ok_cor l1 _ _ a), (index_in_extroduce_ok_cor l2 _ _ h4).
+          clear h2.
+          rewrite index_in_from_extroduce.
+          revert c' h3 i2' h4.
+          set (h3' := IlistPerm3Cert_aux2 (mkilist l1) (mkilist l2) h i1 i2).
+          set (h5 := extroduce_lgti_S l1 i1) ; set (h6 := extroduce_lgti_S l2 i2).
+          generalize h3' h5 h6 ; clear h3' h5 h6.
+          set (l1' := extroduce (mkilist l1) i1) ; set (l2' := extroduce (mkilist l2) i2) ;
+            assert (h7 := refl_equal _ : extroduce (mkilist l1) i1 = l1') ; 
+            assert (h8 := refl_equal _ : l2' = extroduce (mkilist l2) i2).
+          destruct l1' as [n1' l1'] ; destruct l2' as [n2' l2'].
+          simpl lgti.
+          intros h3' h5 h6; revert h3' l1' l2' h7 h8.
+          rewrite <- h5, <- h6.
+          clear n1' n2' h5 h6.
+          intros h3' l1' l2' h5 h6 c' h3.
+          fold (mkilist l1') (mkilist l2') in *|-*.
+          rewrite <- IlistPerm3Cert_list_eq.
+          intros i2' h4.
+          do 2 rewrite <- (decode_Fin_unique _ _ (decode_Fin_match' _ _)).
+          apply (IH _ _ _ h3'), h3.
     Qed.
 
     Lemma IlistPerm3Cert_list_function_ok (T: Set)(R: relation T)(l1 l2 : ilist T)(c: IlistPerm3Cert_list (lgti l1)) 
@@ -1757,7 +1716,7 @@ Section IlistPerm_ind.
       forall i, R (fcti l1 i) (fcti l2 (rewriteFins h (IlistPerm3Cert_list_function c i))).
     Proof.
       intros h1 i.
-      destruct l1 as [n l1] ; destruct l2 as [n2 l2] ; simpl in *|-*.
+      destruct l1 as [n l1] ; destruct l2 as [n2 l2] ; cbn in *|-*.
       revert l2 h1 ; rewrite <- h ; intros l2 h1 ; clear n2 h.
       rewrite <- (decode_Fin_unique _ _ (decode_Fin_match' _ _)).
       apply (IlistPerm3Cert_list_function_ok_n h1).
@@ -1770,7 +1729,7 @@ Section IlistPerm_ind.
       intros h1 i.
       assert (h3 : IlistPerm3Cert_list_function c i = rewriteFins 
         (eq_refl _ : lgti (mkilist l1) = lgti (mkilist l2)) (IlistPerm3Cert_list_function c i)).
-      treatFinPure.
+      { treatFinPure. }
       rewrite h3.
       apply (IlistPerm3Cert_list_function_ok h1).
     Qed.
@@ -1805,11 +1764,10 @@ Section IlistPerm_bij.
    Proof.
      intros [f1 g1 h1 h2] [f2 g2 h3 h4].
      apply (perm7  _ _ _ (Bij_trans h1 h3)).
-     
      intro i.
      transitivity (fcti l2 (f1 i)).
-     apply h2.
-     apply h4.
+     - apply h2.
+     - apply h4.
    Qed.
 
    Add Parametric Relation (T: Set)(RelT: relation T)(EqT: Equivalence RelT) : (ilist T)(IlistPerm7 RelT) 
@@ -1837,15 +1795,15 @@ Section IlistPerm_bij.
      Bijective (IlistPerm3Cert_list_function c) (IlistPerm3Cert_list_function_inv c).
    Proof.
      split.
-     apply IP3Cl_function_inv_function_inv.
-     apply IP3Cl_function_function_inv_inv.
+     - apply IP3Cl_function_inv_function_inv.
+     - apply IP3Cl_function_function_inv_inv.
    Qed.
 
    Lemma IlistPerm3_IlistPerm7 (T: Set)(R: relation T)(l1 l2 : ilist T) : 
      IlistPerm3 R l1 l2 -> IlistPerm7 R l1 l2.
    Proof.
      destruct l1 as [n l1] ; destruct l2 as [n2 l2].
-     intros h1 ; assert (h2 := IlistPerm3_lgti h1) ; simpl in *|-* ; revert l1 l2 h1 ; rewrite <- h2 ; clear n2 h2;
+     intros h1 ; assert (h2 := IlistPerm3_lgti h1) ; cbn in *|-* ; revert l1 l2 h1 ; rewrite <- h2 ; clear n2 h2;
      intros l1 l2 h1.
      destruct (IlistPerm3_IlistPerm3Cert (refl_equal _ : lgti (existT _ _ l1) = lgti (existT _ _ l2)) h1) as [c h2].
      fold (mkilist l1) (mkilist l2) in *|-*.
@@ -1857,159 +1815,144 @@ Section IlistPerm_bij.
      IlistPerm7 R l1 l2 -> IlistPerm3 R l1 l2.
    Proof.
      intros h1 ; assert (h := IlistPerm7_lgti h1).
-     destruct l1 as [n l1] ; destruct l2 as [n2 l2] ; simpl in *|-* ; revert l1 l2 h1 ; rewrite <- h ;
-     intros l1 l2 [f g [h1 h2] h3]; clear n2 h ; simpl in *|-*.
-     
+     destruct l1 as [n l1] ; destruct l2 as [n2 l2] ; cbn in *|-* ; revert l1 l2 h1 ; rewrite <- h ;
+     intros l1 l2 [f g [h1 h2] h3]; clear n2 h ; cbn in *|-*.
      induction n as [|n IH].
-     apply IlistPerm3_nil ; reflexivity.
+     { apply IlistPerm3_nil ; reflexivity. }
      apply (IlistPerm3_cons _ _ (first n : Fin (lgti (existT _ _ l1))) (f (first n) :  Fin (lgti (existT _ _ l2)))).
-     apply h3.
-     
+     { apply h3. }     
      assert (hex1_aux := extroduce_lgti (existT _ _ l1) (first n)).
      assert (hex1 : forall i, fcti (extroduce (existT _ _ l1) (first n)) i = fcti (existT _ _ l1)
-     (rewriteFins (eq_sym hex1_aux) (succ i))).
-     intro i.
-     rewrite extroduce_ok3'.
-     f_equal.
-     treatFinPure.
-     apply le_0_n.
-     
+         (rewriteFins (eq_sym hex1_aux) (succ i))).
+     { intro i.
+       rewrite extroduce_ok3'.
+       - f_equal.
+         treatFinPure.
+       - apply le_0_n.
+     }     
      assert (hex2_aux := extroduce_lgti (existT _ _ l2) (f (first n))).
      assert (hex21 : forall i, decode_Fin i < decode_Fin (f (first n)) -> 
-     fcti (extroduce (existT _ _ l2) (f (first n))) i = 
-     fcti (existT _ _ l2) (rewriteFins (eq_sym hex2_aux) (weakFin i))).
-     intros i h4.
-     rewrite extroduce_ok2' ; try assumption.
-     f_equal.
-     treatFinPure.
-     
+         fcti (extroduce (existT _ _ l2) (f (first n))) i = 
+         fcti (existT _ _ l2) (rewriteFins (eq_sym hex2_aux) (weakFin i))).
+     { intros i h4.
+       rewrite extroduce_ok2' ; try assumption.
+       f_equal.
+       treatFinPure. }     
      assert (hex22 : forall i, decode_Fin (f (first n)) <=  decode_Fin i -> 
-     fcti (extroduce (existT _ _ l2) (f (first n))) i = 
-     fcti (existT _ _ l2) (rewriteFins (eq_sym hex2_aux) (succ i))).
-     intros i h4.
-     rewrite extroduce_ok3' ; try assumption.
-     f_equal.
-     treatFinPure.
-     
+         fcti (extroduce (existT _ _ l2) (f (first n))) i = 
+         fcti (existT _ _ l2) (rewriteFins (eq_sym hex2_aux) (succ i))).
+     { intros i h4.
+       rewrite extroduce_ok3' ; try assumption.
+       f_equal.
+       treatFinPure. }     
      revert hex1_aux hex1 hex2_aux hex21 hex22.
      set (l1' := extroduce (existT _ _ l1) (first n)) ; set (l2' := extroduce (existT _ _ l2) (f (first n))).
      assert (h4 := refl_equal _ : l1' =  extroduce (existT _ _ l1) (first n)) ; 
-     assert (h5 := refl_equal _ : l2' =  extroduce (existT _ _ l2) (f (first n))).
+       assert (h5 := refl_equal _ : l2' =  extroduce (existT _ _ l2) (f (first n))).
      destruct l1' as [n' l1'] ; destruct l2' as [n2' l2'].
      assert (h6 : n' = n2').
-     change (lgti (existT (fun n : nat => ilistn T n) _ l1') = lgti (existT (fun n : nat => ilistn T n) _ l2')).
-     rewrite h4, h5.
-     apply extroduce_lgti_S.
+     { change (lgti (existT (fun n : nat => ilistn T n) _ l1') = lgti (existT (fun n : nat => ilistn T n) _ l2')).
+       rewrite h4, h5.
+       apply extroduce_lgti_S. }
      assert (h7 : n' = n).
-     change (lgti (existT (fun n : nat => ilistn T n) _ l1') = n).
-     apply eq_add_S.
-     rewrite h4, <- extroduce_lgti.
-     reflexivity.
+     { change (lgti (existT (fun n : nat => ilistn T n) _ l1') = n).
+       apply eq_add_S.
+       rewrite h4, <- extroduce_lgti.
+       reflexivity. }
      revert l1' l2' h4 h5 ; rewrite <- h6, h7 ; intros l1' l2' h4 h5.
-     simpl.
+     cbn.
      intros hex1_aux hex1 hex2_aux hex21 hex22; 
-     clear n' n2' h6 h7.
-     
+       clear n' n2' h6 h7.
      assert (hex1' : forall i, l1' i = l1 (succ i)).
-     intro i.
-     assert (h6 : succ i = rewriteFins (eq_sym hex1_aux) (succ i)) by treatFinPure.
-     rewrite h6 ; apply hex1.
+     { intro i.
+       assert (h6 : succ i = rewriteFins (eq_sym hex1_aux) (succ i)) by treatFinPure.
+       rewrite h6 ; apply hex1. }
      assert (hex21' : forall i, decode_Fin i < decode_Fin (f (first n)) -> l2' i = l2 (weakFin i)).
-     intros i h6.
-     assert (h7 : weakFin i = rewriteFins (eq_sym hex2_aux) (weakFin i)) by treatFinPure.
-     rewrite h7 ; apply hex21, h6.
+     { intros i h6.
+       assert (h7 : weakFin i = rewriteFins (eq_sym hex2_aux) (weakFin i)) by treatFinPure.
+       rewrite h7 ; apply hex21, h6. }
      assert (hex22' : forall i, decode_Fin (f (first n)) <= decode_Fin i -> l2' i = l2 (succ i)).
-     intros i h6.
-     assert (h7 : succ i = rewriteFins (eq_sym hex2_aux) (succ i)) by treatFinPure.
-     rewrite h7 ; apply hex22, h6.
+     { intros i h6.
+       assert (h7 : succ i = rewriteFins (eq_sym hex2_aux) (succ i)) by treatFinPure.
+       rewrite h7 ; apply hex22, h6. }
      clear hex1_aux hex2_aux hex1 hex21 hex22.
-     
      fold (mkilist l1') (mkilist l2') in *|-*.
-     
      assert (h6 : forall i, decode_Fin (f (first n)) <> decode_Fin (f (@succ n i))).
-     intros i h6.
-     apply decode_Fin_unique, (f_equal g) in h6.
-     do 2 rewrite h1 in h6.
-     inversion h6.
+     { intros i h6.
+       apply decode_Fin_unique, (f_equal g) in h6.
+       do 2 rewrite h1 in h6.
+       inversion h6. }
      set (f' := fun i => index_in_extroduce _ _ (h6 i)).
-     
      assert (h7 : forall i, decode_Fin (first n) <> decode_Fin (g (extroduce_Fin (f (first n)) i))).
-     intro i.
-     unfold extroduce_Fin, sumbool_rec, sumbool_rect.
-     elim (le_lt_dec (decode_Fin (f (first n))) (decode_Fin i)) ; intros a h7 ;
-     apply decode_Fin_unique, (f_equal f) in h7 ; rewrite h2 in h7 ; rewrite h7 in a.
-     apply (le_Sn_n _ a).
-     rewrite weakFin_ok in a.
-     apply (lt_irrefl _ a).
+     { intro i.
+       unfold extroduce_Fin, sumbool_rec, sumbool_rect.
+       elim (le_lt_dec (decode_Fin (f (first n))) (decode_Fin i)) ; intros a h7 ;
+         apply decode_Fin_unique, (f_equal f) in h7 ; rewrite h2 in h7 ; rewrite h7 in a.
+       - apply (le_Sn_n _ a).
+       - rewrite weakFin_ok in a.
+         apply (lt_irrefl _ a).
+     }
      set (g' := fun i => index_in_extroduce _ _ (h7 i)).
-     
      apply (IH _ _ f' g') ; intros i; unfold f', g' ; clear f' g'.
-     assert (h8 : decode_Fin (first n) < decode_Fin (g (extroduce_Fin (f (first n))
-     (index_in_extroduce (f (first n)) (f (succ i)) (h6 i))))).
-     rewrite (index_from_in_extroduce _ _ (h6 i)), h1. 
-     apply lt_0_Sn.
-     apply decode_Fin_unique, eq_add_S.
-     rewrite index_in_extroduce_decode1, (index_from_in_extroduce _ _ (h6 i)), h1 ; try assumption.
-     reflexivity.
-     
-     elim (lt_eq_lt_dec (decode_Fin (f (first n))) (decode_Fin (f (succ (index_in_extroduce (first n)
-       (g (extroduce_Fin (f (first n)) i)) (h7 i)))))) ; try intros [a|a] ; try intros a ; 
-     apply decode_Fin_unique.
-     apply eq_add_S.
-     rewrite index_in_extroduce_decode1 ; try assumption.
-     
-     elim (lt_eq_lt_dec (decode_Fin (first n)) (decode_Fin (g (extroduce_Fin (f (first n)) i)))) ; 
-     try intros [b|b] ; try intros b.
-     rewrite (decode_Fin_unique _ _ (index_in_extroduce_decode1 _ _ (h7 _) b : decode_Fin (succ _) = _)), h2.
-     elim (le_lt_dec (decode_Fin (f (first n))) (decode_Fin i)) ; intros c.
-     rewrite extroduce_Fin_ok1 ; try assumption.
-     reflexivity.
-     apply False_rec.
-     rewrite (decode_Fin_unique _ _ (index_in_extroduce_decode1 _ _ (h7 _) b : decode_Fin (succ _) = _)), h2 in a.
-     rewrite extroduce_Fin_ok2, weakFin_ok in a ; try assumption.
-     apply (lt_irrefl _ (lt_trans _ _ _ a c)).
-     contradiction (h7 i).
-     inversion b.
-     
-     apply decode_Fin_unique, (f_equal g) in a.
-     do 2 rewrite h1 in a.
-     inversion a.
-     
-     rewrite index_in_extroduce_decode2 ; try assumption.
-     revert a ; set (h8 := h7 i) ; generalize h8 ; clear h8.
-     elim (le_lt_dec (decode_Fin (f (first n))) (decode_Fin i)) ; intros b.
-     rewrite extroduce_Fin_ok1 ; try assumption.
-     intros h8 a.
-     elim (lt_eq_lt_dec (decode_Fin (first n)) (decode_Fin (g (succ i)))) ; try intros [c|c] ; try intros c.
-     rewrite (decode_Fin_unique _ _ (index_in_extroduce_decode1 _ _ h8 c : decode_Fin (succ _) = _)), h2 in a.
-     apply False_rec, (le_Sn_n _ (lt_le_weak _ _ (lt_le_trans _ _ _ a b))).
-     contradiction c.
-     inversion c.
-     
-     rewrite extroduce_Fin_ok2 ; try assumption.
-     intros h8 a.
-     elim (lt_eq_lt_dec (decode_Fin (first n)) (decode_Fin (g (weakFin i)))) ; try intros [c|c] ; try intros c.
-     rewrite (decode_Fin_unique _ _ (index_in_extroduce_decode1 _ _ h8 c : decode_Fin (succ _) = _)), h2.
-     apply weakFin_ok.
-     contradiction c.
-     inversion c.
-     
-     set (h8 := h6 i) ; generalize h8 ; clear h8 ; intros h8.
-     rewrite hex1'.
-     
-     assert (h9 : l2' (index_in_extroduce (f (first n)) (f (succ i)) h8) = l2 (f (succ i))).
-     rewrite (index_in_extroduce_ok_cor l2 _ _ h8).
-     set (h9 := extroduce_lgti_S l2 (f (first n))).
-     generalize h9 ; clear h9.
-     change (mkilist l2' = extroduce (mkilist l2) (f (first n))) in h5.
-     rewrite <- h5.
-     intros h9.
-     simpl.
-     f_equal.
-     treatFinPure.
-     
-     rewrite h9.
-     apply h3.
+     - assert (h8 : decode_Fin (first n) < decode_Fin (g (extroduce_Fin (f (first n))
+         (index_in_extroduce (f (first n)) (f (succ i)) (h6 i))))).
+       { rewrite (index_from_in_extroduce _ _ (h6 i)), h1. 
+         apply lt_0_Sn. }
+       apply decode_Fin_unique, eq_add_S.
+       rewrite index_in_extroduce_decode1, (index_from_in_extroduce _ _ (h6 i)), h1 ; try assumption.
+       reflexivity.
+     - elim (lt_eq_lt_dec (decode_Fin (f (first n))) (decode_Fin (f (succ (index_in_extroduce (first n)
+           (g (extroduce_Fin (f (first n)) i)) (h7 i)))))) ; try intros [a|a] ; try intros a ; 
+           apply decode_Fin_unique.
+       + apply eq_add_S.
+         rewrite index_in_extroduce_decode1 ; try assumption.
+         elim (lt_eq_lt_dec (decode_Fin (first n)) (decode_Fin (g (extroduce_Fin (f (first n)) i)))) ; 
+           try intros [b|b] ; try intros b.
+         * rewrite (decode_Fin_unique _ _ (index_in_extroduce_decode1 _ _ (h7 _) b : decode_Fin (succ _) = _)), h2.
+           elim (le_lt_dec (decode_Fin (f (first n))) (decode_Fin i)) ; intros c.
+           -- rewrite extroduce_Fin_ok1 ; try assumption.
+              reflexivity.
+           -- apply False_rec.
+              rewrite (decode_Fin_unique _ _ (index_in_extroduce_decode1 _ _ (h7 _) b : decode_Fin (succ _) = _)), h2 in a.
+              rewrite extroduce_Fin_ok2, weakFin_ok in a ; try assumption.
+              apply (lt_irrefl _ (lt_trans _ _ _ a c)).
+         * contradiction (h7 i).
+         * inversion b.
+       + apply decode_Fin_unique, (f_equal g) in a.
+         do 2 rewrite h1 in a.
+         inversion a.
+       + rewrite index_in_extroduce_decode2 ; try assumption.
+         revert a ; set (h8 := h7 i) ; generalize h8 ; clear h8.
+         elim (le_lt_dec (decode_Fin (f (first n))) (decode_Fin i)) ; intros b.
+         * rewrite extroduce_Fin_ok1 ; try assumption.
+           intros h8 a.
+           elim (lt_eq_lt_dec (decode_Fin (first n)) (decode_Fin (g (succ i)))) ; try intros [c|c] ; try intros c.
+           -- rewrite (decode_Fin_unique _ _ (index_in_extroduce_decode1 _ _ h8 c : decode_Fin (succ _) = _)), h2 in a.
+              apply False_rec, (le_Sn_n _ (lt_le_weak _ _ (lt_le_trans _ _ _ a b))).
+           -- contradiction c.
+           -- inversion c.
+         * rewrite extroduce_Fin_ok2 ; try assumption.
+           intros h8 a.
+           elim (lt_eq_lt_dec (decode_Fin (first n)) (decode_Fin (g (weakFin i)))) ; try intros [c|c] ; try intros c.
+           -- rewrite (decode_Fin_unique _ _ (index_in_extroduce_decode1 _ _ h8 c : decode_Fin (succ _) = _)), h2.
+              apply weakFin_ok.
+           -- contradiction c.
+           -- inversion c.
+     - set (h8 := h6 i) ; generalize h8 ; clear h8 ; intros h8.
+       rewrite hex1'.
+       assert (h9 : l2' (index_in_extroduce (f (first n)) (f (succ i)) h8) = l2 (f (succ i))).
+       { rewrite (index_in_extroduce_ok_cor l2 _ _ h8).
+         set (h9 := extroduce_lgti_S l2 (f (first n))).
+         generalize h9 ; clear h9.
+         change (mkilist l2' = extroduce (mkilist l2) (f (first n))) in h5.
+         rewrite <- h5.
+         intros h9.
+         cbn.
+         f_equal.
+         treatFinPure.
+       }
+       rewrite h9.
+       apply h3.
    Qed.
      
   End IlistPerm_bij.

--- a/Introduce.v
+++ b/Introduce.v
@@ -22,10 +22,10 @@ Proof.
   apply (mkilist (n:=S n)).
   intro f'.
   elim (lt_eq_lt_dec  (decode_Fin f') (decode_Fin f)) ; intros a.
-  destruct a as [a|a].
-  exact (i (code_Fin1 (lt_le_trans _ _ _ a (lt_n_Sm_le _ _ (decode_Fin_inf_n f))))).
-  exact t.
-  exact (i (get_cons f' (lt_n_m_0 a))).
+  - destruct a as [a|a].
+    + exact (i (code_Fin1 (lt_le_trans _ _ _ a (lt_n_Sm_le _ _ (decode_Fin_inf_n f))))).
+    + exact t.
+  - exact (i (get_cons f' (lt_n_m_0 a))).
 Defined.
 
 Lemma introduce_lgti : forall (T: Set)(i: ilist T)(f: Fin (S (lgti i)))(t:T), 
@@ -40,7 +40,7 @@ Lemma introduce_ok1': forall (T: Set)(i: ilist T)(f: Fin (S (lgti i)))(t:T)
   decode_Fin f = decode_Fin f' -> fcti (introduce t i f) f' = t.
 Proof.
   intros T [n i] f t f' h.
-  simpl in *|-*.
+  cbn in *|-*.
   elim (lt_eq_lt_dec (decode_Fin f') (decode_Fin f)) ; intros a; try destruct a as [a|a]; 
   unfold sumor_rec,  sumor_rect;
   try (apply False_rec ; rewrite h in a ; apply (lt_irrefl _ a)).
@@ -53,18 +53,18 @@ Lemma introduce_ok2': forall (T: Set)(i: ilist T)(f: Fin (S (lgti i)))(t:T)
   fcti i (code_Fin1 (lt_le_trans _ _ _ h (lt_n_Sm_le _ _ (decode_Fin_inf_n f)))).
 Proof.
   intros T [n i] f t f' h.
-  simpl in *|-*.
+  cbn in *|-*.
   unfold sumor_rec, sumor_rect.
   elim (lt_eq_lt_dec (decode_Fin f') (decode_Fin f)) ; [intros [a|a]|intros a].
-  f_equal.
-  destruct n as [|n].
-  revert h a ; rewrite (Fin_first_1 f'), (Fin_first_1 f) ; simpl ; intros h a.
-  inversion h.
-  apply code_Fin1_proofirr.
-  apply False_rec, (lt_irrefl (decode_Fin f)).
-  rewrite <- a at 1.
-  assumption.
-  apply False_rec, (lt_irrefl (decode_Fin f) (lt_trans _ _ _ a h)).
+  - f_equal.
+    destruct n as [|n].
+    + revert h a ; rewrite (Fin_first_1 f'), (Fin_first_1 f) ; cbn ; intros h a.
+      inversion h.
+    + apply code_Fin1_proofirr.
+  - apply False_rec, (lt_irrefl (decode_Fin f)).
+    rewrite <- a at 1.
+    assumption.
+  - apply False_rec, (lt_irrefl (decode_Fin f) (lt_trans _ _ _ a h)).
 Qed.
 
 Lemma inf_rewriteFins (n m r: nat)(i: Fin n)(h: n = m) : 
@@ -81,14 +81,14 @@ Lemma introduce_ok3': forall (T: Set)(i: ilist T)(f: Fin (S (lgti i)))(t:T)
   (inf_rewriteFins f' (introduce_lgti _ _ _) (lt_n_m_0 h))).
 Proof.
   intros T [n i] f t f' h.
-  simpl in *|-*.
+  cbn in *|-*.
   unfold sumor_rec, sumor_rect.
   elim (lt_eq_lt_dec (decode_Fin f') (decode_Fin f)) ; [intros a|intros a] ;
   [apply False_rec, (lt_irrefl (decode_Fin f)); destruct a as [a|a] | f_equal].
-  apply (lt_trans _ _ _ h a).
-  rewrite <- a at 2.
-  assumption.
-  apply get_cons_proofirr.
+  - apply (lt_trans _ _ _ h a).
+  - rewrite <- a at 2.
+    assumption.
+  - apply get_cons_proofirr.
 Qed.
 
 Lemma introduce_extroduce_id: forall (T: Set) (RelT : relation T) (EqT: Equivalence RelT)
@@ -98,40 +98,37 @@ Proof.
   intros T RelT EqT i f.
   assert (h: lgti i = lgti (introduce (fcti i f) (extroduce i f)
     (rewriteFins (extroduce_lgti i f) f))).
-  rewrite introduce_lgti.
-  apply extroduce_lgti.
+  { rewrite introduce_lgti.
+    apply extroduce_lgti. }
   apply (is_ilist_rel _ _ _ h).
   intro f'.
   destruct i as [n i].
   simpl in f, f'.
   fold (mkilist i) in *|-*.
   change (fcti (mkilist i)) with i in *|-*.
-  
   elim (lt_eq_lt_dec (decode_Fin (rewriteFins h f')) 
     (decode_Fin (rewriteFins (extroduce_lgti (mkilist i) f) f)));
   try intros [b|b]; try intro b.
-  rewrite (introduce_ok2' _ _ _ _ b ).
-  rewrite extroduce_ok2'.
-  apply (fRel EqT).
-  treatFinPure.
-  rewrite decode_code1_Id.
-  rewrite <- (decode_Fin_match' _ (extroduce_lgti (mkilist i) f)) in b.
-  assumption.
-  
-  rewrite introduce_ok1'.
-  apply (fRel EqT), decode_Fin_unique.
-  do 2 rewrite <- decode_Fin_match' in b.
-  assumption.
-  symmetry ; assumption.
-  
-  rewrite (introduce_ok3' _ _ _ _ b ).
-  rewrite extroduce_ok3'.
-  apply (fRel EqT).
-  treatFinPure.
-  apply le_S_n.
-  rewrite <- decode_Fin_get_cons, <- decode_Fin_match'.
-  rewrite <- (decode_Fin_match' _ (extroduce_lgti (mkilist i) f)) in b.
-  apply gt_le_S, b.
+  - rewrite (introduce_ok2' _ _ _ _ b ).
+    rewrite extroduce_ok2'.
+    + apply (fRel EqT).
+      treatFinPure.
+    + rewrite decode_code1_Id.
+      rewrite <- (decode_Fin_match' _ (extroduce_lgti (mkilist i) f)) in b.
+      assumption.
+  - rewrite introduce_ok1'.
+    + apply (fRel EqT), decode_Fin_unique.
+      do 2 rewrite <- decode_Fin_match' in b.
+      assumption.
+    + symmetry ; assumption.
+  - rewrite (introduce_ok3' _ _ _ _ b ).
+    rewrite extroduce_ok3'.
+    + apply (fRel EqT).
+      treatFinPure.
+    + apply le_S_n.
+      rewrite <- decode_Fin_get_cons, <- decode_Fin_match'.
+      rewrite <- (decode_Fin_match' _ (extroduce_lgti (mkilist i) f)) in b.
+      apply gt_le_S, b.
 Qed.
 
 Lemma extroduce_introduce_id (T: Set) (RelT : relation T) (EqT: Equivalence RelT)
@@ -140,37 +137,36 @@ Lemma extroduce_introduce_id (T: Set) (RelT : relation T) (EqT: Equivalence RelT
 Proof.
   assert (h : lgti i = lgti (extroduce (introduce t i f)
      (rewriteFins (Logic.eq_sym (introduce_lgti i f t)) f))).
-  apply eq_add_S.
-  rewrite <- extroduce_lgti, introduce_lgti.
-  reflexivity.
+  { apply eq_add_S.
+    rewrite <- extroduce_lgti, introduce_lgti.
+    reflexivity. }
   apply (is_ilist_rel _ _ _ h).
   intros f'.
   elim (le_lt_dec (decode_Fin f) (decode_Fin f')) ; intros a.
-  rewrite extroduce_ok3'.
-  assert (h' : decode_Fin f < decode_Fin (rewriteFins (Logic.eq_sym
-    (extroduce_lgti (introduce t i f) 
-    (rewriteFins (Logic.eq_sym (introduce_lgti i f t)) f))) (succ (rewriteFins h f')))).
-  rewrite <- decode_Fin_match'.
-  simpl.
-  rewrite <- decode_Fin_match'.
-  apply le_lt_n_Sm, a.
-  rewrite (introduce_ok3' _ _ _ _ h').
-  apply (fRel EqT).
-  treatFinPure.
-  do 2 rewrite <- decode_Fin_match'.
-  assumption.
-
-  rewrite extroduce_ok2'.
-  assert (h' : decode_Fin  (rewriteFins (Logic.eq_sym (extroduce_lgti (introduce t i f)
+  - rewrite extroduce_ok3'.
+    + assert (h' : decode_Fin f < decode_Fin (rewriteFins (Logic.eq_sym
+          (extroduce_lgti (introduce t i f) 
+             (rewriteFins (Logic.eq_sym (introduce_lgti i f t)) f))) (succ (rewriteFins h f')))).
+      { rewrite <- decode_Fin_match'.
+        cbn.
+        rewrite <- decode_Fin_match'.
+        apply le_lt_n_Sm, a. }
+      rewrite (introduce_ok3' _ _ _ _ h').
+      apply (fRel EqT).
+      treatFinPure.
+    + do 2 rewrite <- decode_Fin_match'.
+      assumption.
+  - rewrite extroduce_ok2'.
+    + assert (h' : decode_Fin  (rewriteFins (Logic.eq_sym (extroduce_lgti (introduce t i f)
     (rewriteFins (Logic.eq_sym (introduce_lgti i f t)) f))) (weakFin (rewriteFins h f'))) 
     < decode_Fin f).
-  rewrite <- decode_Fin_match', weakFin_ok, <- decode_Fin_match'.
-  assumption.
-  rewrite (introduce_ok2' _ _ _ _ h').
-  apply (fRel EqT).
-  treatFinPure.
-  do 2 rewrite <- decode_Fin_match'.
-  assumption.
+      { rewrite <- decode_Fin_match', weakFin_ok, <- decode_Fin_match'.
+        assumption. }
+      rewrite (introduce_ok2' _ _ _ _ h').
+      apply (fRel EqT).
+      treatFinPure.
+    + do 2 rewrite <- decode_Fin_match'.
+      assumption.
 Qed.
 
 

--- a/ListEq.v
+++ b/ListEq.v
@@ -29,11 +29,11 @@ Add Parametric Morphism (A: Set): (ListEq(A:= A))
 Proof.
   intros eqA1 eqA2 HypSub t1 t2 Hyp.
   induction Hyp as [|a1 a2 l1 l2 e Hyp IH].
-  apply ListEq_nil.
-  apply ListEq_cons.  
-  apply HypSub.
-  assumption.
-  assumption.
+  - apply ListEq_nil.
+  - apply ListEq_cons.  
+    + apply HypSub.
+      assumption.
+    + assumption.
 Qed.
 
 (* proof that ListEq is an equivalence relation *)
@@ -42,10 +42,10 @@ Instance ListEq_refl : forall (A: Set)(eqA: relation A)`{Reflexive A eqA},
 Proof.
   intros A eqA reflA x.
   induction x as [| a la IHl].
-  apply ListEq_nil.
-  apply ListEq_cons.
-  reflexivity.
-  assumption.
+  - apply ListEq_nil.
+  - apply ListEq_cons.
+    + reflexivity.
+    + assumption.
 Qed.
 
 Instance ListEq_sym : forall (A: Set)(eqA: relation A)`{Symmetric A eqA},
@@ -53,10 +53,10 @@ Instance ListEq_sym : forall (A: Set)(eqA: relation A)`{Symmetric A eqA},
 Proof.
   intros A eqA symA x y H.
   induction H as [|a1 a2 l1 l2 e H IH].
-  apply ListEq_nil.
-  apply ListEq_cons; 
-  [symmetry|];
-  assumption.
+  - apply ListEq_nil.
+  - apply ListEq_cons; 
+      [symmetry|];
+      assumption.
 Qed.
 
 Instance ListEq_trans: forall (A: Set)(eqA: relation A)`{Transitive A eqA},
@@ -65,12 +65,12 @@ Proof.
   intros A eqA transA x y z H1 H2.
   revert z H2.
   induction H1 as [|a1 a2 x y e1 H1 IH1]; intros z H2.
-  assumption.
-  destruct z as [|a3 z] ;
-  inversion_clear H2 as [| a4 a5 l1 l2 e2 H3].
-  apply ListEq_cons.
-  apply (transA _ _ _ e1 e2).
-  apply (IH1 _ H3).
+  - assumption.
+  - destruct z as [|a3 z] ;
+      inversion_clear H2 as [| a4 a5 l1 l2 e2 H3].
+    apply ListEq_cons.
+    + apply (transA _ _ _ e1 e2).
+    + apply (IH1 _ H3).
 Qed.
 
 Add Parametric Relation (A: Set)(eqA: relation A)`{Reflexive A eqA}: 
@@ -90,10 +90,10 @@ Instance ListEqeqeq : forall(A: Set), subrelation (ListEq (@eq A)) (@eq (list A)
 Proof.
   intros A x x0 H.
   induction H as [| a1 a2 l1 l2 e1 H IH].
-  reflexivity.
-  rewrite IH.
-  rewrite e1.
-  reflexivity.
+  - reflexivity.
+  - rewrite IH.
+    rewrite e1.
+    reflexivity.
 Qed.
 
 Instance eqListEqeq : forall (A: Set), subrelation (@eq (list A)) (ListEq (@eq A)).
@@ -167,8 +167,8 @@ Lemma ListEq_map_f_g:
 Proof.
   intros A B cmpB f g l h.
   induction l as [| hd l].
-  apply ListEq_nil.
-  apply (ListEq_cons _ _ (h hd) IHl).
+  - apply ListEq_nil.
+  - apply (ListEq_cons _ _ (h hd) IHl).
 Qed.
 
 Lemma ListEq_length: forall (A: Set)(cmpA: relation A)(l1 l2: list A), 
@@ -190,10 +190,10 @@ Proof.
   intros A cmpA cmpAR ; 
   induction l1 as [|hd1 l1 IHl] ; destruct l2 as [| hd2 l2]; 
   intros n h d le; try (inversion_clear le as [| x y z t e H]).
-  reflexivity.
-  destruct n as [|n].
-  assumption.
-  apply (IHl _ _ (lt_S_n _ _ h) _ H).
+  - reflexivity.
+  - destruct n as [|n].
+  + assumption.
+  + apply (IHl _ _ (lt_S_n _ _ h) _ H).
 Qed.
 
 Lemma ListEq_eq: forall (A B: Set)
@@ -203,13 +203,13 @@ Lemma ListEq_eq: forall (A B: Set)
 Proof.
   intros A B cmpB cmpBR ; 
   induction l as [| hd l IHl]; intros f1 f2 H a Hin.
-  inversion Hin.
-  inversion_clear H as [| x y z t e h].
-  destruct Hin as [eq | Hin].
-  rewrite <- eq.
-  assumption.
-  apply IHl;
-  assumption.
+  - inversion Hin.
+  - inversion_clear H as [| x y z t e h].
+    destruct Hin as [eq | Hin].
+    + rewrite <- eq.
+      assumption.
+    + apply IHl;
+        assumption.
 Qed.
 
 End additional_functions.

--- a/NatSeg.v
+++ b/NatSeg.v
@@ -130,17 +130,17 @@ Definition transformI (n n': nat)(i: NatSeg n -> NatSeg n')
   (ns: NatSeg n): NatSeg n'.
 Proof.
   destruct n as [|n].
-  apply False_rec.
-  apply (NatSeg_0_empty ns).
-  destruct n' as [|n'].
-  apply False_rec.
-  apply (NatSeg_0_empty (i ns)).
-  elim (eq_nat_dec (elem (i ns)) n'); intros a.
-  exact (i (makeNatSeg (lt_n_Sn n))).
-  elim (le_lt_eq_dec (elem ns) n (lt_n_Sm_le (elem ns) n (proof_lt ns))); 
-  intros b.
-  exact (i ns ).
-  exact ((makeNatSeg (lt_n_Sn n'))).
+  - apply False_rec.
+    apply (NatSeg_0_empty ns).
+  - destruct n' as [|n'].
+    + apply False_rec.
+      apply (NatSeg_0_empty (i ns)).
+    + elim (eq_nat_dec (elem (i ns)) n'); intros a.
+      * exact (i (makeNatSeg (lt_n_Sn n))).
+      * elim (le_lt_eq_dec (elem ns) n (lt_n_Sm_le (elem ns) n (proof_lt ns))); 
+          intros b.
+        -- exact (i ns).
+        -- exact ((makeNatSeg (lt_n_Sn n'))).
 Defined.
 
 (* Transforms a function i of type : NatSeg (S n) -> NatSeg n' into a 
@@ -264,7 +264,7 @@ Lemma mkLessI_i_Id:
 Proof.
   intros n n' ns h i H .
   apply is_natSeg_eq_gen.
-  simpl.
+  cbn.
   rewrite elem_bij.
   apply H.
   apply is_natSeg_eq.
@@ -356,37 +356,37 @@ Proof.
   intros [|n] n' i j Hypi Hypj Idji Idij ns ;
   unfold natSeg_morph in Hypi;
   unfold natSeg_morph in Hypj.
-  no_NatSeg_0 ns.
-  destruct n' as [|n'].
-  no_NatSeg_0 (i ns).
-  unfold_transformI.
-  elim (eq_nat_dec (elem (i ns)) n'); intros a.
-  elim (eq_nat_dec (elem (j (i (makeNatSeg (lt_n_Sn n))))) n); 
-  intros b.
-  apply (makeNatSeg_ns_natSegeq (i ns) (lt_n_Sn n')) in a.
-  rewrite <- a.
-  apply Idji.
-  rewrite Idji in b.
-  contradiction b ; reflexivity.
-  elim (le_lt_eq_dec (elem ns) n); intros b.
-  elim (eq_nat_dec (elem (j (i ns))) n); intros c.
-  rewrite Idji in c.
-  rewrite c in b.
-  apply False_rec.
-  apply (lt_irrefl n b).
-  elim (le_lt_eq_dec (elem (i ns)) n'); intros d.
-  apply Idji.
-  contradiction d ; reflexivity.
-  elim (eq_nat_dec (elem (j (makeNatSeg (lt_n_Sn n')))) n); intros c.
-  apply is_natSeg_eq.
-  rewrite c.
-  apply (sym_eq b).
-  elim (le_lt_eq_dec (elem (makeNatSeg (lt_n_Sn n'))) n'); intros d.
-  apply False_rec.
-  apply (lt_irrefl n' d).
-  symmetry.
-  apply (makeNatSeg_ns_natSegeq ns (lt_n_Sn n)).
-  assumption.
+  - no_NatSeg_0 ns.
+  - destruct n' as [|n'].
+    + no_NatSeg_0 (i ns).
+    + unfold_transformI.
+      elim (eq_nat_dec (elem (i ns)) n'); intros a.
+      * elim (eq_nat_dec (elem (j (i (makeNatSeg (lt_n_Sn n))))) n); 
+          intros b.
+        -- apply (makeNatSeg_ns_natSegeq (i ns) (lt_n_Sn n')) in a.
+           rewrite <- a.
+           apply Idji.
+        -- rewrite Idji in b.
+           contradiction b ; reflexivity.
+      * elim (le_lt_eq_dec (elem ns) n); intros b.
+        -- elim (eq_nat_dec (elem (j (i ns))) n); intros c.
+           ++ rewrite Idji in c.
+              rewrite c in b.
+              apply False_rec.
+              apply (lt_irrefl n b).
+           ++ elim (le_lt_eq_dec (elem (i ns)) n'); intros d.
+              ** apply Idji.
+              ** contradiction d ; reflexivity.
+        -- elim (eq_nat_dec (elem (j (makeNatSeg (lt_n_Sn n')))) n); intros c.
+           ++ apply is_natSeg_eq.
+              rewrite c.
+              apply (sym_eq b).
+           ++ elim (le_lt_eq_dec (elem (makeNatSeg (lt_n_Sn n'))) n'); intros d.
+              ** apply False_rec.
+                 apply (lt_irrefl n' d).
+              ** symmetry.
+                 apply (makeNatSeg_ns_natSegeq ns (lt_n_Sn n)).
+                 assumption.
 Qed.
 
 Lemma not_NatSeg_eq: forall (n: nat)(ns1 ns2: NatSeg n), 
@@ -417,30 +417,30 @@ Proof.
   intros n n' ns i j Hypj Idji h.
   unfold_transformI.
   elim (eq_nat_dec (elem (i ns)) n'); intros a.
-  elim (eq_nat_dec (elem (ns)) (elem (makeNatSeg (lt_n_Sn n)))); intros b.
-  rewrite b in h.
-  apply False_rec.
-  apply (lt_irrefl n h).
-  elim (le_lt_eq_dec (elem (i (makeNatSeg (lt_n_Sn n)))) n') ;
-  try (intro c).
-  assumption.
-  rewrite <- a in c.
-  rewrite elem_bij in c.
-  apply (j_i_inj (makeNatSeg (lt_n_Sn n)) ns i Hypj Idji) in c.
-  destruct c as [c].
-  rewrite c in b.
-  contradiction b.
-  reflexivity.
-  apply lt_n_Sm_le.
-  apply elem_lt_n.
-  elim (le_lt_eq_dec (elem ns) n); intro b.
-  elim (not_eq (elem (i ns)) n' a); intro c.
-  assumption.
-  apply False_rec.
-  apply (lt_irrefl _ (lt_le_trans _ _ _ c (lt_n_Sm_le _ _ (elem_lt_n (i ns))))).
-  rewrite b in h.
-  apply False_rec.
-  apply (lt_irrefl _ h).
+  - elim (eq_nat_dec (elem (ns)) (elem (makeNatSeg (lt_n_Sn n)))); intros b.
+    + rewrite b in h.
+      apply False_rec.
+      apply (lt_irrefl n h).
+    + elim (le_lt_eq_dec (elem (i (makeNatSeg (lt_n_Sn n)))) n') ;
+        try (intro c).
+      * assumption.
+      * rewrite <- a in c.
+        rewrite elem_bij in c.
+        apply (j_i_inj (makeNatSeg (lt_n_Sn n)) ns i Hypj Idji) in c.
+        destruct c as [c].
+        rewrite c in b.
+        contradiction b.
+        reflexivity.
+      * apply lt_n_Sm_le.
+        apply elem_lt_n.
+  -  elim (le_lt_eq_dec (elem ns) n); intro b.
+     + elim (not_eq (elem (i ns)) n' a); intro c.
+       * assumption.
+       * apply False_rec.
+         apply (lt_irrefl _ (lt_le_trans _ _ _ c (lt_n_Sm_le _ _ (elem_lt_n (i ns))))).
+     + rewrite b in h.
+       apply False_rec.
+       apply (lt_irrefl _ h).
 Qed.
 
 (* We define a function that given a function i: NatSeg (S n)-> NatSeg (S n'), 
@@ -452,9 +452,9 @@ Definition mkLessI_transform(n n': nat)
   (ns: NatSeg n): NatSeg n'.
 Proof.
   assert (H: elem (transformI i (transfoSNs ns)) < n').
-  apply (transformI_lt_n (transfoSNs ns) i Hypj HInv).
-  destruct ns as [m h].
-  assumption.
+  { apply (transformI_lt_n (transfoSNs ns) i Hypj HInv).
+    destruct ns as [m h].
+    assumption. }
   exact (transfoNs (transformI i (transfoSNs ns)) H).
 Defined.
 
@@ -513,35 +513,35 @@ Proof.
   intros x y h.
   unfold natSeg_morph in Hypi.
   destruct n as [|n].
-  no_NatSeg_0 x.
+  { no_NatSeg_0 x. }
   destruct n' as [|n'].
-  no_NatSeg_0 (i x).
+  { no_NatSeg_0 (i x). }
   unfold_transformI.
   elim (eq_nat_dec (elem (i x)) n'); 
-  elim (eq_nat_dec (elem (i y)) n'); intros a b ; 
-  try reflexivity.
-  apply (natSeg_eq_surj Hypi) in h; 
-  destruct h as [h].
-  rewrite b in h.
-  symmetry in h.
-  contradiction a.
-  apply (natSeg_eq_surj Hypi) in h; 
-  destruct h as [h].
-  rewrite a in h.
-  contradiction b.
-  elim (le_lt_eq_dec (elem x) n); elim (le_lt_eq_dec (elem y) n); intros c d.
-  apply (natSeg_eq_surj Hypi) in h; 
-  destruct h as [h].
-  apply (is_natSeg_eq _ _ h).
-  rewrite <- c in d.
-  destruct h as [h].
-  rewrite h in d.
-  apply False_rec; apply (lt_irrefl _ d).
-  rewrite <- d in c.
-  destruct h as [h].
-  rewrite h in c.
-  apply False_rec; apply (lt_irrefl _ c).
-  reflexivity.
+   elim (eq_nat_dec (elem (i y)) n'); intros a b ; 
+   try reflexivity.
+  - apply (natSeg_eq_surj Hypi) in h; 
+      destruct h as [h].
+    rewrite b in h.
+    symmetry in h.
+    contradiction a.
+  - apply (natSeg_eq_surj Hypi) in h; 
+      destruct h as [h].
+    rewrite a in h.
+    contradiction b.
+  - elim (le_lt_eq_dec (elem x) n); elim (le_lt_eq_dec (elem y) n); intros c d.
+    + apply (natSeg_eq_surj Hypi) in h; 
+        destruct h as [h].
+      apply (is_natSeg_eq _ _ h).
+    + rewrite <- c in d.
+      destruct h as [h].
+      rewrite h in d.
+      apply False_rec; apply (lt_irrefl _ d).
+    + rewrite <- d in c.
+      destruct h as [h].
+      rewrite h in c.
+      apply False_rec; apply (lt_irrefl _ c).
+    + reflexivity.
 Qed.
 
 Lemma transform_bij: forall (n n': nat)(ns ns': NatSeg n)
@@ -553,52 +553,52 @@ Proof.
   intros n n' ns ns' i j Hypi Hypj Idji.
   unfold natSeg_morph in Hypi; unfold natSeg_morph in Hypj.
   split.
-  destruct n as [|n].
-  no_NatSeg_0 ns.
-  destruct n' as [|n'].
-  no_NatSeg_0 (i ns).
-  unfold_transformI.
-  elim (eq_nat_dec (elem (i ns)) n'); elim (eq_nat_dec (elem (i ns')) n');
-  intros a b.
-  intro H.
-  rewrite <- a in b.
-  rewrite elem_bij in b.
-  apply (j_i_inj ns ns' i Hypj Idji b).
-  elim (le_lt_eq_dec (elem ns') n ); try (intros c H).
-  apply (j_i_inj (makeNatSeg (lt_n_Sn n)) ns' i Hypj Idji) in H.
-  rewrite <- H in c.
-  apply False_rec.
-  apply (lt_irrefl n c).
-  rewrite (makeNatSeg_ns_natSegeq ns' (lt_n_Sn n)) in c.
-  rewrite <- c in H.
-  rewrite H in a.
-  contradiction a; reflexivity.
-  elim (le_lt_eq_dec (elem ns) n );
-  intros c H.
-  apply (j_i_inj ns (makeNatSeg (lt_n_Sn n)) i Hypj Idji) in H.
-  rewrite H in c.
-  apply False_rec. 
-  apply (lt_irrefl n c).
-  rewrite (makeNatSeg_ns_natSegeq ns (lt_n_Sn n)) in c.
-  rewrite <- c in H.
-  rewrite <- H in b.
-  contradiction b; reflexivity.
-  elim (le_lt_eq_dec (elem ns) n); elim (le_lt_eq_dec (elem ns') n); 
-  intros c d H.
-  apply (j_i_inj ns ns' i Hypj Idji H).
-  rewrite H in b.
-  contradiction b; reflexivity.
-  rewrite <- H in a.
-  contradiction a; reflexivity.
-  apply is_natSeg_eq.
-  rewrite c.
-  assumption.
-  intros H.
-  assert (H1: natSeg_morph (transformI i)).
-  exact (transformIM j Hypi).
-  unfold natSeg_morph in H1.
-  rewrite <- H.
-  reflexivity.
+  - destruct n as [|n].
+    { no_NatSeg_0 ns. }
+    destruct n' as [|n'].
+    { no_NatSeg_0 (i ns). }
+    unfold_transformI.
+    elim (eq_nat_dec (elem (i ns)) n'); elim (eq_nat_dec (elem (i ns')) n');
+      intros a b.
+    + intro H.
+      rewrite <- a in b.
+      rewrite elem_bij in b.
+      apply (j_i_inj ns ns' i Hypj Idji b).
+    + elim (le_lt_eq_dec (elem ns') n ); try (intros c H).
+      * apply (j_i_inj (makeNatSeg (lt_n_Sn n)) ns' i Hypj Idji) in H.
+        rewrite <- H in c.
+        apply False_rec.
+        apply (lt_irrefl n c).
+      * rewrite (makeNatSeg_ns_natSegeq ns' (lt_n_Sn n)) in c.
+        rewrite <- c in H.
+        rewrite H in a.
+        contradiction a; reflexivity.
+    + elim (le_lt_eq_dec (elem ns) n );
+        intros c H.
+      * apply (j_i_inj ns (makeNatSeg (lt_n_Sn n)) i Hypj Idji) in H.
+        rewrite H in c.
+        apply False_rec. 
+        apply (lt_irrefl n c).
+      * rewrite (makeNatSeg_ns_natSegeq ns (lt_n_Sn n)) in c.
+        rewrite <- c in H.
+        rewrite <- H in b.
+        contradiction b; reflexivity.
+    + elim (le_lt_eq_dec (elem ns) n); elim (le_lt_eq_dec (elem ns') n); 
+        intros c d H.
+      * apply (j_i_inj ns ns' i Hypj Idji H).
+      * rewrite H in b.
+        contradiction b; reflexivity.
+      * rewrite <- H in a.
+        contradiction a; reflexivity.
+      * apply is_natSeg_eq.
+        rewrite c.
+        assumption.
+  - intros H.
+    assert (H1: natSeg_morph (transformI i)).
+    { exact (transformIM j Hypi). }
+    unfold natSeg_morph in H1.
+    rewrite <- H.
+    reflexivity.
 Qed.
 
 Lemma transform_exist: 
@@ -609,8 +609,7 @@ Lemma transform_exist:
   transformI i (exist (fun m : nat => m < n) (elem ns) h) ~ transformI i ns.
 Proof.
   intros n n' ns h i j Hypi Hypj Idji.
-  rewrite (transform_bij (exist (fun m : nat => m < n) (elem ns) h) ns 
-  Hypi Hypj Idji).
+  rewrite (transform_bij (exist (fun m : nat => m < n) (elem ns) h) ns Hypi Hypj Idji).
   symmetry.
   apply (exist_id3 ns h).
 Qed.
@@ -626,26 +625,26 @@ Proof.
   unfold natSeg_morph in Hypi.
   unfold natSeg_morph in Hypj.
   assert (HMi: natSeg_morph (transformI i)).
-  exact (transformIM j Hypi).
+  { exact (transformIM j Hypi). }
   unfold natSeg_morph in HMi.
   assert (HMj: natSeg_morph (transformI j)).
-  exact (transformIM i Hypj).
+  { exact (transformIM i Hypj). }
   unfold natSeg_morph in HMj.
   apply is_natSeg_eq.
   rewrite mkLessI_transform_transformI_elem_eq.
   assert (H: (exist (fun m : nat => m < S n')
-  (elem (transformI i (exist (fun m : nat => m < S n) m (lt_S m n h))))
-  (lt_S (elem 
-  (transformI i (exist (fun m : nat => m < S n) m (lt_S m n h)))) n'
-  (transformI_lt_n (exist (fun m : nat => m < S n) m (lt_S m n h)) i
-  Hypj Idji h))) ~ 
-  (transformI i (exist (fun m : nat => m < S n) m (lt_S m n h)))).
-  apply is_natSeg_eq.
-  reflexivity.
+    (elem (transformI i (exist (fun m : nat => m < S n) m (lt_S m n h))))
+    (lt_S (elem 
+    (transformI i (exist (fun m : nat => m < S n) m (lt_S m n h)))) n'
+    (transformI_lt_n (exist (fun m : nat => m < S n) m (lt_S m n h)) i
+    Hypj Idji h))) ~ 
+    (transformI i (exist (fun m : nat => m < S n) m (lt_S m n h)))).
+  { apply is_natSeg_eq.
+    reflexivity. }
   rewrite H.
   apply (makeNatSeg_ns_natSegeq (transformI j
-  (transformI i (exist (fun m : nat => m < S n) m (lt_S m n h)))) 
-  (lt_S m n h)).
+    (transformI i (exist (fun m : nat => m < S n) m (lt_S m n h)))) 
+    (lt_S m n h)).
   apply (transform_Id Hypi Hypj Idji Idij).
 Qed.  
 
@@ -660,12 +659,12 @@ Proof.
   intros x y H.
   unfold mkLessI_transform.
   assert (HMi: natSeg_morph (transformI i)).
-  exact (transformIM j Hypi).
+  { exact (transformIM j Hypi). }
   unfold natSeg_morph in HMi.
   unfold natSeg_morph in Hypi.
   apply is_natSeg_eq.
   change (elem (transformI i (transfoSNs x)) =  
-  (elem (transformI i (transfoSNs y)))).
+    (elem (transformI i (transfoSNs y)))).
   rewrite H.
   reflexivity.
 Qed.
@@ -682,16 +681,16 @@ Proof.
   induction n as [|n IHn]; destruct n' as [|n']; 
   intros i j Hypi Hypj Idji Idij; 
   unfold natSeg_morph in Hypi ; unfold natSeg_morph in Hypj.
-  apply le_refl.
-  apply le_O_n.
-  apply False_rec.
-  apply (NatSeg_0_empty (i (makeNatSeg (lt_n_Sn n)))).
-  apply (le_n_S n n').
-  set (Hypi':= mkLessI_transformM Hypi Hypj Idji ).
-  set (Hypj':= mkLessI_transformM Hypj Hypi Idij).
-  apply (IHn n' (mkLessI_transform i Hypj Idji) (mkLessI_transform j Hypi Idij)
-    Hypi' Hypj' (mkLessI_transform_id Hypi Hypj Idji Idij) 
-    (mkLessI_transform_id Hypj Hypi Idij Idji)).
+  - apply le_refl.
+  - apply le_O_n.
+  - apply False_rec.
+    apply (NatSeg_0_empty (i (makeNatSeg (lt_n_Sn n)))).
+  - apply (le_n_S n n').
+    set (Hypi':= mkLessI_transformM Hypi Hypj Idji ).
+    set (Hypj':= mkLessI_transformM Hypj Hypi Idij).
+    apply (IHn n' (mkLessI_transform i Hypj Idji) (mkLessI_transform j Hypi Idij)
+      Hypi' Hypj' (mkLessI_transform_id Hypi Hypj Idji Idij) 
+      (mkLessI_transform_id Hypj Hypi Idij Idji)).
 Defined.
 
 (* Finally, we show that if there is a bijection between NatSeg n 

--- a/Paths.v
+++ b/Paths.v
@@ -21,12 +21,12 @@ Section GeqPath.
     Definition label_path (T: Set)(l: list nat): forall (g: Graph T), option T.
     Proof.
       induction l as [| a l IH].
-      intros [t _].
-      exact (Some t).
-      intros [_ [n ln]].
-      elim (le_lt_dec n a) ; intros h.
-      exact None.
-      exact (IH (ln (code_Fin1 h))).
+      - intros [t _].
+        exact (Some t).
+      - intros [_ [n ln]].
+        elim (le_lt_dec n a) ; intros h.
+        + exact None.
+        + exact (IH (ln (code_Fin1 h))).
     Defined.
     
     Definition graph_test: Graph nat.
@@ -34,9 +34,9 @@ Section GeqPath.
       apply (mk_Graph 0).
       set (n00 := mk_Graph 5 (singleton (mk_Graph 6 (inil _)))).
       assert (sn1 : ilistn (Graph nat) 2).
-      set (n11 := mk_Graph 4 (inil _)).
-      set (n10 := mk_Graph 3 (singleton  n11)).
-      exact (fun f => match f with first _ => n10 | succ _ => n11 end).
+      { set (n11 := mk_Graph 4 (inil _)).
+        set (n10 := mk_Graph 3 (singleton  n11)).
+        exact (fun f => match f with first _ => n10 | succ _ => n11 end). }
       apply (@mkilist _ 2 (fun f => match f with first _ => mk_Graph 1 (singleton n00) | 
         succ _ => mk_Graph 2 (mkilist sn1) end)).
     Defined.
@@ -79,16 +79,16 @@ Section GeqPath.
       label_path (n :: nil) g = Some (label (fcti (sons g) (code_Fin1 h))).
     Proof.
       destruct g as [t [ng ln]].
-      simpl in *|-*.
+      cbn in *|-*.
       unfold sumbool_rec, sumbool_rect.
       elim (le_lt_dec ng n) ; intros a.
-      apply False_rec, (lt_irrefl _ (lt_le_trans _ _ _ h a)).
-      assert (H: code_Fin1 a = code_Fin1 h).
-      apply decode_Fin_unique ; do 2 rewrite decode_code1_Id.
-      reflexivity.
-      rewrite H.
-      set (g := ln (code_Fin1 h)) ; destruct g as [tg sg].
-      reflexivity.
+      - apply False_rec, (lt_irrefl _ (lt_le_trans _ _ _ h a)).
+      - assert (H: code_Fin1 a = code_Fin1 h).
+        { apply decode_Fin_unique ; do 2 rewrite decode_code1_Id.
+          reflexivity. }
+        rewrite H.
+        set (g := ln (code_Fin1 h)) ; destruct g as [tg sg].
+        reflexivity.
     Qed.
 
     Lemma label_path_sons_gene (T: Set)(RelT : relation T)(g: Graph T)(n: nat)(l: list nat)
@@ -98,39 +98,39 @@ Section GeqPath.
       simpl in *|-*.
       unfold sumbool_rec, sumbool_rect.
       elim (le_lt_dec n' n) ; intros a.
-      apply False_rec, (lt_irrefl n'), (le_lt_trans _ _ _ a h).
-      do 2 f_equal.
-      treatFinPure.
+      - apply False_rec, (lt_irrefl n'), (le_lt_trans _ _ _ a h).
+      - do 2 f_equal.
+        treatFinPure.
     Qed.
 
     Lemma label_path_inf_n (T: Set)(RelT : relation T)(g: Graph T)(n: nat)(t: T):
       label_path (n :: nil) g = Some t -> n < lgti (sons g).
     Proof.
       destruct g as [gt [ng ln]].
-      simpl in *|-*.
+      cbn in *|-*.
       elim (le_lt_dec ng n) ; intros H a.
-      inversion a.
-      assumption.
+      - inversion a.
+      - assumption.
     Qed.
 
     Lemma label_path_inf_n_rel (T: Set)(RelT : relation T)(g: Graph T)(n: nat)(t: T):
       RelOp RelT (label_path (n :: nil) g) (Some t) -> n < lgti (sons g).
     Proof.
       destruct g as [gt [ng ln]].
-      simpl in *|-*.
+      cbn in *|-*.
       elim (le_lt_dec ng n) ; intros H a.
-      inversion a.
-      assumption.
+      - inversion a.
+      - assumption.
     Qed.
 
     Lemma label_path_inf_n_rel_sym (T: Set)(RelT : relation T)(g: Graph T)(n: nat)(t: T):
       RelOp RelT (Some t) (label_path (n :: nil) g) -> n < lgti (sons g).
     Proof.
       destruct g as [gt [ng ln]].
-      simpl in *|-*.
+      cbn in *|-*.
       elim (le_lt_dec ng n) ; intros H a.
-      inversion a.
-      assumption.
+      - inversion a.
+      - assumption.
     Qed.
     
     Lemma GeqPath_lgti (T: Set)(RelT: relation T)(g1 g2: Graph T): 
@@ -139,25 +139,22 @@ Section GeqPath.
       intros H.
       destruct g1 as [t1 [[|n1] ln1]] ;  destruct g2 as [t2 [[|n2] ln2]] ; 
       fold (mkilist ln1) (mkilist ln2) in *|-* ; 
-      simpl ; unfold GeqPath in H.
-
-      reflexivity.
-
-      assert (H' := H (n2 :: nil)).
-      rewrite (label_path_sons RelT (mk_Graph t2 (mkilist ln2)) (lt_n_Sn n2)) in H'.
-      inversion H'.
-      assert (H' := H (n1 :: nil)).
-      rewrite (label_path_sons RelT (mk_Graph t1 (mkilist ln1)) (lt_n_Sn n1)) in H'.
-      inversion H'.
-
-      assert (H1 := H (n1 :: nil)).
-      rewrite (label_path_sons RelT (mk_Graph t1 (mkilist ln1)) (lt_n_Sn n1)) in H1.
-      assert (H1lgti := label_path_inf_n_rel_sym RelT _ _ _ H1).
-      assert (H2 := H (n2 :: nil)).
-      rewrite (label_path_sons RelT (mk_Graph t2 (mkilist ln2)) (lt_n_Sn n2)) in H2.
-      assert (H2lgti := label_path_inf_n_rel RelT _ _ _ H2).
-      rewrite (le_antisym _ _ (lt_n_Sm_le _ _ H1lgti) (lt_n_Sm_le _ _ H2lgti)).
-      reflexivity.
+      cbn ; unfold GeqPath in H.
+      - reflexivity.
+      - assert (H' := H (n2 :: nil)).
+        rewrite (label_path_sons RelT (mk_Graph t2 (mkilist ln2)) (lt_n_Sn n2)) in H'.
+        inversion H'.
+      - assert (H' := H (n1 :: nil)).
+        rewrite (label_path_sons RelT (mk_Graph t1 (mkilist ln1)) (lt_n_Sn n1)) in H'.
+        inversion H'.
+      - assert (H1 := H (n1 :: nil)).
+        rewrite (label_path_sons RelT (mk_Graph t1 (mkilist ln1)) (lt_n_Sn n1)) in H1.
+        assert (H1lgti := label_path_inf_n_rel_sym RelT _ _ _ H1).
+        assert (H2 := H (n2 :: nil)).
+        rewrite (label_path_sons RelT (mk_Graph t2 (mkilist ln2)) (lt_n_Sn n2)) in H2.
+        assert (H2lgti := label_path_inf_n_rel RelT _ _ _ H2).
+        rewrite (le_antisym _ _ (lt_n_Sm_le _ _ H1lgti) (lt_n_Sm_le _ _ H2lgti)).
+        reflexivity.
     Qed.
 
     Lemma GeqPath_refl (T: Set)(RelT: relation T)(Req: Equivalence RelT)(g: Graph T): 
@@ -181,8 +178,8 @@ Section GeqPath.
         destruct g3 as [t3 [n3 ln3]].
       apply (RelOp_trans _ _ (label_path l
        (mk_Graph t2 (existT (fun n : nat => ilistn (Graph T) n) n2 ln2)))).
-      apply (H1 l).
-      apply (H2 l).
+      - apply (H1 l).
+      - apply (H2 l).
     Qed.
 
     Add Parametric Relation (T: Set)(RelT: relation T)(Req: Equivalence RelT): 
@@ -197,28 +194,28 @@ Section GeqPath.
     Proof.
       revert g1 g2 ; cofix Hc ; intros [t1 [n1 ln1]] [t2 [n2 ln2]] H ; 
       fold (mkilist ln1) (mkilist ln2) in *|-*.
-      apply Geq_intro  ; simpl in *|-*.
-      unfold GeqPath in H.
-      apply (H nil).
-      assert (h1 := GeqPath_lgti H : lgti (mkilist ln1) = lgti (mkilist ln2)).
-      apply (is_ilist_rel _ _ _ h1).
-      simpl in *|-*.
-      intro f.
-      apply Hc.
-      intro l.
-      assert (H' := H ((decode_Fin f) :: l)).
-      rewrite (label_path_sons_gene RelT _ _ (decode_Fin_inf_n f : 
-        decode_Fin f < lgti (sons (mk_Graph t1 (mkilist ln1))))) 
-        in H'.
-      assert (H1 := decode_Fin_inf_n f).
-      rewrite h1 in H1.
-      change n2 with (lgti (sons (mk_Graph t2 (mkilist ln2)))) in H1.
-      rewrite (label_path_sons_gene RelT _ _ H1) in H'.
-      simpl in H'.
-      rewrite code1_decode_Id in H'.
-      assert (H2 : code_Fin1 H1 = rewriteFins h1 f) by treatFinPure.
-      rewrite <- H2.
-      assumption.
+      apply Geq_intro  ; cbn in *|-*.
+      - unfold GeqPath in H.
+        apply (H nil).
+      - assert (h1 := GeqPath_lgti H : lgti (mkilist ln1) = lgti (mkilist ln2)).
+        apply (is_ilist_rel _ _ _ h1).
+        cbn in *|-*.
+        intro f.
+        apply Hc.
+        intro l.
+        assert (H' := H ((decode_Fin f) :: l)).
+        rewrite (label_path_sons_gene RelT _ _ (decode_Fin_inf_n f : 
+            decode_Fin f < lgti (sons (mk_Graph t1 (mkilist ln1))))) 
+            in H'.
+        assert (H1 := decode_Fin_inf_n f).
+        rewrite h1 in H1.
+        change n2 with (lgti (sons (mk_Graph t2 (mkilist ln2)))) in H1.
+        rewrite (label_path_sons_gene RelT _ _ H1) in H'.
+        cbn in H'.
+        rewrite code1_decode_Id in H'.
+        assert (H2 : code_Fin1 H1 = rewriteFins h1 f) by treatFinPure.
+        rewrite <- H2.
+        assumption.
     Qed.
     
     Lemma Geq_GeqPath (T: Set)(RelT: relation T)(g1 g2: Graph T): 
@@ -226,51 +223,51 @@ Section GeqPath.
     Proof.
       intros H l ; revert g1 g2 H ; induction l as [|n q IH] ;
       intros _ _ [[t1 [n1 ln1]] [t2 [n2 ln2]] h1 [h3 h4]].
-      assumption.
-      simpl in *|-*.
-      unfold sumbool_rec, sumbool_rect.
-      assert (h5 := h3) ; revert ln2 h3 h4 ; rewrite <- h5 ; clear n2 h5 ; intros ln2 h3 h4.
-      elim (le_lt_dec n1 n) ; intros a.
-      reflexivity.
-      apply IH.
-      assert (h5 : code_Fin1 a = rewriteFins h3 (code_Fin1 a)) by treatFinPure.
-      rewrite h5 at 2.
-      apply h4.
+      - assumption.
+      - cbn in *|-*.
+        unfold sumbool_rec, sumbool_rect.
+        assert (h5 := h3) ; revert ln2 h3 h4 ; rewrite <- h5 ; clear n2 h5 ; intros ln2 h3 h4.
+        elim (le_lt_dec n1 n) ; intros a.
+        { reflexivity. }
+        apply IH.
+        assert (h5 : code_Fin1 a = rewriteFins h3 (code_Fin1 a)) by treatFinPure.
+        rewrite h5 at 2.
+        apply h4.
     Qed.
 
     Definition getGraph_path (T: Set)(l: list nat)(g: Graph T): option (Graph T).
     Proof.
       revert g.
       induction l as [|n l IH].
-      intros g ; exact (Some g).
-      intros [labg [lgtig sonsg]].
-      elim (le_lt_dec lgtig n) ; intros a.
-      exact None.
-      exact (IH (sonsg (code_Fin1 a))).
+      - intros g ; exact (Some g).
+      - intros [labg [lgtig sonsg]].
+        elim (le_lt_dec lgtig n) ; intros a.
+        + exact None.
+        + exact (IH (sonsg (code_Fin1 a))).
     Defined. 
      
     Lemma getGraph_path_labelpath_None (T: Set)(l: list nat)(g: Graph T) : 
       getGraph_path l g = None -> label_path l g = None.
     Proof.
       revert g ; induction l as [|n l IH] ; intros [labg [lgtig sonsg]].
-      intro H ; inversion H.
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgtig n) ; intros a.
-      reflexivity.
-      apply IH.
+      - intro H ; inversion H.
+      - cbn.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgtig n) ; intros a.
+        + reflexivity.
+        + apply IH.
     Qed.
       
     Lemma labelpath_getGraph_path_None (T: Set)(l: list nat)(g: Graph T) : 
       label_path l g = None -> getGraph_path l g = None.
     Proof.
       revert g ; induction l as [|n l IH] ; intros [labg [lgtig sonsg]].
-      intro H ; inversion H.
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgtig n) ; intros a.
-      reflexivity.
-      apply IH.
+      - intro H ; inversion H.
+      - cbn.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgtig n) ; intros a.
+        + reflexivity.
+        + apply IH.
     Qed.
 
     Lemma getGraph_path_labelpath_Some (T: Set)(l: list nat)(g: Graph T)(RelT: relation T): 
@@ -278,19 +275,19 @@ Section GeqPath.
       exists lab, RelOp RelT (label_path l g) (Some lab).
     Proof.
       revert g ; induction l as [|n l IH] ; intros [labg [lgtig sonsg]].
-      intros [[labg' sonsg'] H].
-      exists labg'.
-      inversion H as [g1 g2 H1 H2 h1 h2] ; clear g1 g2 h1 h2.
-      simpl in *|-*.
-      assumption.
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgtig n) ; intros a.
-      intros [g' H].
-      inversion H.
-      intros [[labg' sonsg'] H].
-      apply IH.
-      exists (mk_Graph labg' sonsg'); assumption.
+      - intros [[labg' sonsg'] H].
+        exists labg'.
+        inversion H as [g1 g2 H1 H2 h1 h2] ; clear g1 g2 h1 h2.
+        cbn in *|-*.
+        assumption.
+      - cbn.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgtig n) ; intros a.
+        + intros [g' H].
+          inversion H.
+        + intros [[labg' sonsg'] H].
+          apply IH.
+          exists (mk_Graph labg' sonsg'); assumption.
     Qed.
 
     Lemma labelpath_getGraph_path_Some (T: Set)(l: list nat)(g: Graph T)(RelT: relation T)
@@ -298,21 +295,21 @@ Section GeqPath.
       (exists g', RelOp (Geq RelT) (getGraph_path l g) (Some g')).
     Proof.
       revert g ; induction l as [|n l IH] ; intros [labg [lgtig sonsg]].
-      intros [lab H].
-      simpl in *|-*.
-      exists (mk_Graph lab (existT (fun n : nat => ilistn (Graph T) n) lgtig sonsg)).
-      apply Geq_intro.
-      simpl.
-      assumption.
-      simpl.
-      apply (ilist_rel_refl (Geq_refl _)).
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgtig n) ; intros a.
-      intros [lab H] ; inversion H.
-      intros [lab H].
-      apply IH.
-      exists lab ; assumption.
+      - intros [lab H].
+        cbn in *|-*.
+        exists (mk_Graph lab (existT (fun n : nat => ilistn (Graph T) n) lgtig sonsg)).
+        apply Geq_intro.
+        + cbn.
+          assumption.
+        + cbn.
+          apply (ilist_rel_refl (Geq_refl _)).
+      - cbn.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgtig n) ; intros a.
+        + intros [lab H] ; inversion H.
+        + intros [lab H].
+          apply IH.
+          exists lab ; assumption.
     Qed.
 
     Lemma getGraph_path_GinG (T: Set)(g g': Graph T)(RelT: relation T): 
@@ -320,23 +317,23 @@ Section GeqPath.
     Proof.
       intro H.
       induction H as [[lab1 [lgti1 sons1]] i1 H3|[lab1 [lgti1 sons1]] i1 H3 [l IH]].
-      exists (decode_Fin i1 :: nil).
-      simpl in *|-*.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 (decode_Fin i1)) ; intros a.
-      apply (lt_irrefl _ (le_lt_trans _ _ _ a (decode_Fin_inf_n i1))).
-      assert (h: code_Fin1 a = i1).
-      apply decode_Fin_unique, decode_code1_Id.
-      rewrite h ; assumption.
-      exists (decode_Fin i1 :: l).
-      simpl in *|-*.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 (decode_Fin i1)) ; intros a.
-      apply (lt_irrefl _ (le_lt_trans _ _ _ a (decode_Fin_inf_n i1))).
-      assert (h: code_Fin1 a = i1).
-      apply decode_Fin_unique, decode_code1_Id.
-      rewrite h.
-      apply IH.
+      - exists (decode_Fin i1 :: nil).
+        cbn in *|-*.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 (decode_Fin i1)) ; intros a.
+        + apply (lt_irrefl _ (le_lt_trans _ _ _ a (decode_Fin_inf_n i1))).
+        + assert (h: code_Fin1 a = i1).
+          { apply decode_Fin_unique, decode_code1_Id. }
+          rewrite h ; assumption.
+      - exists (decode_Fin i1 :: l).
+        cbn in *|-*.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 (decode_Fin i1)) ; intros a.
+        + apply (lt_irrefl _ (le_lt_trans _ _ _ a (decode_Fin_inf_n i1))).
+        + assert (h: code_Fin1 a = i1).
+          { apply decode_Fin_unique, decode_code1_Id. }
+          rewrite h.
+          apply IH.
     Qed.
 
     Lemma getGraph_path_GinG2 (T: Set)(g g': Graph T)(RelT: relation T): 
@@ -345,23 +342,23 @@ Section GeqPath.
     Proof.
       intro H.
       induction H as [[lab1 [lgti1 sons1]] i1 H3|[lab1 [lgti1 sons1]] i1 H3 [n [l IH]]].
-      exists (decode_Fin i1) ; exists nil.
-      simpl in *|-*.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 (decode_Fin i1)) ; intros a.
-      apply (lt_irrefl _ (le_lt_trans _ _ _ a (decode_Fin_inf_n i1))).
-      assert (h: code_Fin1 a = i1).
-      apply decode_Fin_unique, decode_code1_Id.
-      rewrite h ; assumption.
-      exists (decode_Fin i1); exists (n :: l).
-      simpl in *|-*.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 (decode_Fin i1)) ; intros a.
-      apply (lt_irrefl _ (le_lt_trans _ _ _ a (decode_Fin_inf_n i1))).
-      assert (h: code_Fin1 a = i1).
-      apply decode_Fin_unique, decode_code1_Id.
-      rewrite h.
-      apply IH.
+      - exists (decode_Fin i1) ; exists nil.
+        cbn in *|-*.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 (decode_Fin i1)) ; intros a.
+        + apply (lt_irrefl _ (le_lt_trans _ _ _ a (decode_Fin_inf_n i1))).
+        + assert (h: code_Fin1 a = i1).
+          { apply decode_Fin_unique, decode_code1_Id. }
+          rewrite h ; assumption.
+      - exists (decode_Fin i1); exists (n :: l).
+        cbn in *|-*.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 (decode_Fin i1)) ; intros a.
+        + apply (lt_irrefl _ (le_lt_trans _ _ _ a (decode_Fin_inf_n i1))).
+        + assert (h: code_Fin1 a = i1).
+          { apply decode_Fin_unique, decode_code1_Id. }
+          rewrite h.
+          apply IH.
     Qed.
 
     Lemma getGraph_path_GinG3 (T: Set)(g g': Graph T)(RelT: relation T): 
@@ -372,8 +369,8 @@ Section GeqPath.
       destruct (getGraph_path_GinG2 H) as [n [l H1]].
       exists (n :: l).
       split.
-      assumption.
-      apply lt_O_Sn.
+      - assumption.
+      - apply lt_O_Sn.
     Qed.
 
     Lemma getGraph_path_Some_in (T: Set)(g: Graph T)(l: list nat)(RelT: relation T)
@@ -384,38 +381,37 @@ Section GeqPath.
       intros [g' H].
       exists g'.
       split.
-      assumption.
+      { assumption. }
       destruct l as [|n l].
-      simpl in H.
-      right; assumption.
-      left.
-      simpl in H.
-      destruct g as [labg [lgtig sonsg]].
-      unfold sumbool_rec, sumbool_rect in H.
-      revert H.
-      elim (le_lt_dec lgtig n).
-      intros a H.
-      inversion H.
-      revert labg lgtig sonsg n g'.
-      induction l as [|n' l IH] ;
-      intros labg lgtig sonsg n [labg' sonsg'] a H.
-      simpl in H.
-      apply (is_Graph_in_Graph_dir _ 
-        (code_Fin1 a : Fin (lgti (sons (mk_Graph labg (existT _ lgtig sonsg)))))).
-      apply (Geq_sym _ H).
-      
-      apply (is_Graph_in_Graph_indir _ 
-        (code_Fin1 a : Fin (lgti (sons (mk_Graph labg (existT _ lgtig sonsg)))))).
-      simpl.
-      revert H.
-      set (g := sonsg (code_Fin1 a)).
-      set (g' := (mk_Graph labg' sonsg')).
-      destruct g as [labg2 [lgtig2 sonsg2]].
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgtig2 n') ; intros b H.
-      inversion H.
-      apply (IH _ _ _ _ _ _  H).
+      - cbn in H.
+        right; assumption.
+      - left.
+        cbn in H.
+        destruct g as [labg [lgtig sonsg]].
+        unfold sumbool_rec, sumbool_rect in H.
+        revert H.
+        elim (le_lt_dec lgtig n).
+        + intros a H.
+          inversion H.
+        + revert labg lgtig sonsg n g'.
+          induction l as [|n' l IH] ;
+            intros labg lgtig sonsg n [labg' sonsg'] a H.
+          * cbn in H.
+            apply (is_Graph_in_Graph_dir _ 
+              (code_Fin1 a : Fin (lgti (sons (mk_Graph labg (existT _ lgtig sonsg)))))).
+            apply (Geq_sym _ H).
+          * apply (is_Graph_in_Graph_indir _ 
+              (code_Fin1 a : Fin (lgti (sons (mk_Graph labg (existT _ lgtig sonsg)))))).
+            cbn.
+            revert H.
+            set (g := sonsg (code_Fin1 a)).
+            set (g' := (mk_Graph labg' sonsg')).
+            destruct g as [labg2 [lgtig2 sonsg2]].
+            cbn.
+            unfold sumbool_rec, sumbool_rect.
+            elim (le_lt_dec lgtig2 n') ; intros b H.
+            -- inversion H.
+            -- apply (IH _ _ _ _ _ _  H).
    Qed.
 
     Lemma getGraph_path_Some_in2 (T: Set)(g: Graph T)(l: list nat)(RelT: relation T)
@@ -426,12 +422,12 @@ Section GeqPath.
       assert (H1 := getGraph_path_Some_in g l EqT).
       destruct H1 as [g'' [H1 [H2 |H2]]] ; 
       try assert (H3 := RelOp_trans (Geq_trans _) _ _ _ (RelOp_sym (Geq_sym _) _ _ H) H1).
-      exists g'.
-      assumption.
-      left.
-      apply (Graph_in_GraphM2 EqT (Geq_sym _ H3) H2).
-      right.
-      apply (Geq_trans _ H2 (Geq_sym _ H3)).
+      - exists g'.
+        assumption.
+      - left.
+        apply (Graph_in_GraphM2 EqT (Geq_sym _ H3) H2).
+      - right.
+        apply (Geq_trans _ H2 (Geq_sym _ H3)).
    Qed.
 
     Lemma getGraph_path_Some_cons_in (T: Set)(g: Graph T)(n: nat)(l: list nat)(RelT: relation T)
@@ -441,13 +437,13 @@ Section GeqPath.
       revert g n g'.
       induction l as [| n' l IH] ; 
       intros [labg [lgtig sonsg]] n g' ;
-      simpl ; unfold sumbool_rec, sumbool_rect; elim (le_lt_dec lgtig n) ; intros a H.
-      inversion H.
-      apply (is_Graph_in_Graph_dir _ 
-        (code_Fin1 a : Fin (lgti (sons (mk_Graph labg (existT _ lgtig sonsg))))) (Geq_sym _ H)).
-      inversion H.
-      apply (is_Graph_in_Graph_indir _ 
-        (code_Fin1 a : Fin (lgti (sons (mk_Graph labg (existT _ lgtig sonsg))))) (IH _ _ _ H)).
+      cbn ; unfold sumbool_rec, sumbool_rect; elim (le_lt_dec lgtig n) ; intros a H.
+      - inversion H.
+      - apply (is_Graph_in_Graph_dir _ 
+          (code_Fin1 a : Fin (lgti (sons (mk_Graph labg (existT _ lgtig sonsg))))) (Geq_sym _ H)).
+      - inversion H.
+      - apply (is_Graph_in_Graph_indir _ 
+          (code_Fin1 a : Fin (lgti (sons (mk_Graph labg (existT _ lgtig sonsg))))) (IH _ _ _ H)).
    Qed.
 
    Lemma getGraph_path_Some_cons_in2 (T: Set)(g: Graph T)(l: list nat)(RelT: relation T)
@@ -456,8 +452,8 @@ Section GeqPath.
    Proof.
      intros h1 h2.
      destruct l as [|n l].
-     apply False_rec, (lt_irrefl _ h2).
-     apply (getGraph_path_Some_cons_in _ n l EqT _ h1).
+     - apply False_rec, (lt_irrefl _ h2).
+     - apply (getGraph_path_Some_cons_in _ n l EqT _ h1).
    Qed.
 
 End GeqPath.
@@ -471,61 +467,61 @@ Section GeqPermPath.
     Definition EquivPaths (l1 : list nat)(g1: Graph T)(l2 : list nat)(g2 : Graph T): Prop.
     Proof.
       revert g1 g2 l2 ; induction l1 as [|n1 l1 IH] ; intros [lab1 sons1] [lab2 sons2] [|n2 l2].
-      (* empty paths: we must check that the labels are equivalent
-         and that the labels of the sons are permutations *)
-      exact (RelT lab1 lab2 /\ IlistPerm3 RelT (imap (@label _) sons1) (imap (@label _) sons2)).
-      (* one path is empty but the other is not ==> not equivalent *) 
-      exact False.
-      (* one path is empty but the other is not ==> not equivalent *) 
-      exact False.
-      (* both paths are not empty *)
-      destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2].
-      (* We check that both index are indeed index of the concerned ilist *)
-      elim (le_lt_dec lgti1 n1) ; intros a ;
-      elim (le_lt_dec lgti2 n2) ; intros b.
-      (* both indexes are not correct ==> equivalent ? *)
-      exact True.
-      (* one is index but the other not ==> not equivalent *)
-      exact False.
-      (* one is index but the other not ==> equivalent *)
-      exact False.
-      (* both are good indexes : we must check that the labels of respective nodes are equivalent
-         and that the rest of the paths are equivalent *)
-      set (g1' := ln1 (code_Fin1 a)) ; set (g2' := ln2 (code_Fin1 b)).
-      exact (RelT (label g1') (label g2') /\ (IH g1' g2' l2)).
+      - (* empty paths: we must check that the labels are equivalent
+          and that the labels of the sons are permutations *)
+        exact (RelT lab1 lab2 /\ IlistPerm3 RelT (imap (@label _) sons1) (imap (@label _) sons2)).
+      - (* one path is empty but the other is not ==> not equivalent *) 
+        exact False.
+      - (* one path is empty but the other is not ==> not equivalent *) 
+        exact False.
+      - (* both paths are not empty *)
+        destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2].
+        (* We check that both index are indeed index of the concerned ilist *)
+        elim (le_lt_dec lgti1 n1) ; intros a ;
+          elim (le_lt_dec lgti2 n2) ; intros b.
+        + (* both indices are not correct ==> equivalent ? *)
+          exact True.
+        + (* one is index but the other not ==> not equivalent *)
+          exact False.
+        + (* one is index but the other not ==> equivalent *)
+          exact False.
+        + (* both are good indices : we must check that the labels of respective nodes are equivalent
+             and that the rest of the paths are equivalent *)
+          set (g1' := ln1 (code_Fin1 a)) ; set (g2' := ln2 (code_Fin1 b)).
+          exact (RelT (label g1') (label g2') /\ (IH g1' g2' l2)).
     Defined.
 
     Lemma EquivPaths_refl : forall l g, EquivPaths l g l g.
     Proof.
       induction l as [|n l IH] ; intros [lab1 sons1].
-      split.
-      reflexivity.
-      apply (IlistPerm3_refl Req).
-      destruct sons1 as [lgti1 ln1].
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 n) ; intros a.
-      reflexivity.
-      split.
-      reflexivity.
-      apply IH.
+      - split.
+        + reflexivity.
+        + apply (IlistPerm3_refl Req).
+      - destruct sons1 as [lgti1 ln1].
+        cbn.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 n) ; intros a.
+        + reflexivity.
+        + split.
+          * reflexivity.
+          * apply IH.
     Qed.
    
     Lemma EquivPaths_sym : forall l1 l2 g1 g2, EquivPaths l1 g1 l2 g2 -> EquivPaths l2 g2 l1 g1.
     Proof.
       induction l1 as [|n1 l1 IH] ; intros [|n2 l2] [lab1 sons1] [lab2 sons2] H.
-      destruct H as [H1 H2].
-      split ; [symmetry | apply (IlistPerm3_sym Req)] ; assumption.
-      destruct H.
-      destruct H.
-      destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2].
-      revert H.
-      simpl in *|-*.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 n1) ; intros a ; elim (le_lt_dec lgti2 n2) ; intros b H ; 
-      try assumption.
-      destruct H as [H1 H2].
-      split ; [symmetry |apply IH] ; assumption.
+      - destruct H as [H1 H2].
+        split ; [symmetry | apply (IlistPerm3_sym Req)] ; assumption.
+      - destruct H.
+      - destruct H.
+      - destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2].
+        revert H.
+        cbn in *|-*.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 n1) ; intros a ; elim (le_lt_dec lgti2 n2) ; intros b H ; 
+          try assumption.
+        destruct H as [H1 H2].
+        split ; [symmetry |apply IH] ; assumption.
     Qed.
    
     Lemma EquivPaths_trans : forall l1 l2 l3 g1 g2 g3, 
@@ -534,98 +530,97 @@ Section GeqPermPath.
       induction l1 as [|n1 l1 IH] ;
       intros [|n2 l2] [|n3 l3] [lab1 sons1] [lab2 sons2] [lab3 sons3] H1 H2 ; 
       try apply H1 ; try apply H2.
-      destruct H1 as [H11 H12] ; destruct H2 as [H21 H22].
-      split.
-      transitivity lab2 ; assumption.
-      apply IlistPerm4_IlistPerm3_eq.
-      apply IlistPerm3_IlistPerm4_eq in H22.
-      apply IlistPerm3_IlistPerm4_eq in H12.
-      apply (IlistPerm4_trans Req H12 H22).
-      inversion H2.
-      inversion H2.
-      
-      destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2] ; 
-      destruct sons3 as [lgti3 ln3].
-      revert H1 H2.
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 n1) ; intros a ; elim (le_lt_dec lgti2 n2) ; intros b ; 
-      elim (le_lt_dec lgti3 n3) ; intros c H1 H2 ; try assumption. 
-      reflexivity.
-      inversion H1.
-      destruct H1 as [H11 H12] ; destruct H2 as [H21 H22].
-      split.
-      transitivity (label (ln2 (code_Fin1 b))) ; assumption.
-      apply (IH _ _ _ _ _ H12 H22).
+      - destruct H1 as [H11 H12] ; destruct H2 as [H21 H22].
+        split.
+        + transitivity lab2 ; assumption.
+        + apply IlistPerm4_IlistPerm3_eq.
+          apply IlistPerm3_IlistPerm4_eq in H22.
+          apply IlistPerm3_IlistPerm4_eq in H12.
+          apply (IlistPerm4_trans Req H12 H22).
+      - inversion H2.
+      - inversion H2.
+      - destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2] ; 
+          destruct sons3 as [lgti3 ln3].
+        revert H1 H2.
+        cbn.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 n1) ; intros a ; elim (le_lt_dec lgti2 n2) ; intros b ; 
+          elim (le_lt_dec lgti3 n3) ; intros c H1 H2 ; try assumption. 
+        + reflexivity.
+        + inversion H1.
+        + destruct H1 as [H11 H12] ; destruct H2 as [H21 H22].
+          split.
+          * transitivity (label (ln2 (code_Fin1 b))) ; assumption.
+          * apply (IH _ _ _ _ _ H12 H22).
     Qed.
 
     Lemma EquivPaths_nil : forall g1 g2 l, EquivPaths nil g1 l g2 -> l = nil.
     Proof.
       destruct l as [|t l]; intro H.
-      reflexivity.
-      destruct g1 as [lab1 sons1] ; destruct g2 as [lab2 sons2].
-      inversion H.
+      - reflexivity.
+      - destruct g1 as [lab1 sons1] ; destruct g2 as [lab2 sons2].
+        inversion H.
     Qed.
   
     (* Definitions that two paths through two graphs are equivalent *)
     Definition EquivPathsBis (l1 : list nat)(g1: Graph T)(l2 : list nat)(g2 : Graph T): Prop.
     Proof.
       revert g1 g2 l2 ; induction l1 as [|n1 l1 IH] ; intros [lab1 sons1] [lab2 sons2] [|n2 l2].
-      (* empty paths: we must check that the labels are equivalent
-         and that the labels of the sons are permutations *)
-      exact (RelT lab1 lab2).
-      (* one path is empty but the other is not ==> not equivalent *) 
-      exact False.
-      (* one path is empty but the other is not ==> not equivalent *) 
-      exact False.
-      (* both paths are not empty *)
+      - (* empty paths: we must check that the labels are equivalent
+           and that the labels of the sons are permutations *)
+        exact (RelT lab1 lab2).
+      - (* one path is empty but the other is not ==> not equivalent *) 
+        exact False.
+      - (* one path is empty but the other is not ==> not equivalent *) 
+        exact False.
+      - (* both paths are not empty *)
       destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2].
       (* We check that both index are indeed index of the concerned ilist *)
       elim (le_lt_dec lgti1 n1) ; intros a ;
-      elim (le_lt_dec lgti2 n2) ; intros b.
-      (* both indexes are not correct ==> equivalent ? *)
-      exact True.
-      (* one is index but the other not ==> not equivalent *)
-      exact False.
-      (* one is index but the other not ==> equivalent *)
-      exact False.
-      (* both are good indexes : we must check that the labels of respective nodes are equivalent
+        elim (le_lt_dec lgti2 n2) ; intros b.
+      + (* both indices are not correct ==> equivalent ? *)
+        exact True.
+      + (* one is index but the other not ==> not equivalent *)
+        exact False.
+      + (* one is index but the other not ==> equivalent *)
+        exact False.
+      + (* both are good indices : we must check that the labels of respective nodes are equivalent
          and that the rest of the paths are equivalent *)
-      set (g1' := ln1 (code_Fin1 a)) ; set (g2' := ln2 (code_Fin1 b)).
-      exact (RelT (label g1') (label g2') /\ (IH g1' g2' l2)).
+        set (g1' := ln1 (code_Fin1 a)) ; set (g2' := ln2 (code_Fin1 b)).
+        exact (RelT (label g1') (label g2') /\ (IH g1' g2' l2)).
     Defined.
 
     Lemma EquivPathsBis_refl : forall l g, EquivPathsBis l g l g.
     Proof.
       induction l as [|n l IH] ; intros [lab1 sons1].
-      simpl.
-      reflexivity.
-      destruct sons1 as [lgti1 ln1].
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 n) ; intros a.
-      reflexivity.
-      split.
-      reflexivity.
-      apply IH.
+      - cbn.
+        reflexivity.
+      - destruct sons1 as [lgti1 ln1].
+        cbn.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 n) ; intros a.
+        + reflexivity.
+        + split.
+          * reflexivity.
+          * apply IH.
     Qed.
    
     Lemma EquivPathsBis_sym : forall l1 l2 g1 g2, EquivPathsBis l1 g1 l2 g2 -> 
       EquivPathsBis l2 g2 l1 g1.
     Proof.
       induction l1 as [|n1 l1 IH] ; intros [|n2 l2] [lab1 sons1] [lab2 sons2] H.
-      simpl in *|-*.
-      symmetry; assumption.
-      destruct H.
-      destruct H.
-      destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2].
-      revert H.
-      simpl in *|-*.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 n1) ; intros a ; elim (le_lt_dec lgti2 n2) ; intros b H ; 
-      try assumption.
-      destruct H as [H1 H2].
-      split ; [symmetry |apply IH] ; assumption.
+      - cbn in *|-*.
+        symmetry; assumption.
+      - destruct H.
+      - destruct H.
+      - destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2].
+        revert H.
+        cbn in *|-*.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 n1) ; intros a ; elim (le_lt_dec lgti2 n2) ; intros b H ; 
+          try assumption.
+        destruct H as [H1 H2].
+        split ; [symmetry |apply IH] ; assumption.
     Qed.
    
     Lemma EquivPathsBis_trans : forall l1 l2 l3 g1 g2 g3, 
@@ -634,24 +629,23 @@ Section GeqPermPath.
       induction l1 as [|n1 l1 IH] ;
       intros [|n2 l2] [|n3 l3] [lab1 sons1] [lab2 sons2] [lab3 sons3] H1 H2 ; 
       try apply H1 ; try apply H2.
-      simpl in *|-*.
-      transitivity lab2 ; assumption.
-      inversion H1.
-      inversion H1.
-      
-      destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2] ; 
-      destruct sons3 as [lgti3 ln3].
-      revert H1 H2.
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 n1) ; intros a ; elim (le_lt_dec lgti2 n2) ; intros b ; 
-      elim (le_lt_dec lgti3 n3) ; intros c H1 H2 ; try assumption. 
-      reflexivity.
-      inversion H1.
-      destruct H1 as [H11 H12] ; destruct H2 as [H21 H22].
-      split.
-      transitivity (label (ln2 (code_Fin1 b))) ; assumption.
-      apply (IH _ _ _ _ _ H12 H22).
+      - cbn in *|-*.
+        transitivity lab2 ; assumption.
+      - inversion H1.
+      - inversion H1.
+      - destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2] ; 
+          destruct sons3 as [lgti3 ln3].
+        revert H1 H2.
+        cbn.
+        unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 n1) ; intros a ; elim (le_lt_dec lgti2 n2) ; intros b ; 
+          elim (le_lt_dec lgti3 n3) ; intros c H1 H2 ; try assumption. 
+        + reflexivity.
+        + inversion H1.
+        + destruct H1 as [H11 H12] ; destruct H2 as [H21 H22].
+          split.
+          * transitivity (label (ln2 (code_Fin1 b))) ; assumption.
+          * apply (IH _ _ _ _ _ H12 H22).
     Qed.
 
     Lemma EquivPaths_EquivPathsBis : forall l1 l2 g1 g2, 
@@ -659,13 +653,13 @@ Section GeqPermPath.
     Proof.
       induction l1 as [|n1 l1 IH] ;
       intros [|n2 l2] [lab1 [lgti1 sons1]] [lab2 [lgti2 sons2]] ; try (intros H1 ; assumption).
-      intros [H1 _] ; assumption.
-      simpl ; unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 n1) ; elim (le_lt_dec lgti2 n2) ; intros b a H1 ; try assumption.
-      destruct H1 as [H1 H2].
-      split.
-      assumption.
-      apply (IH _ _ _ H2).
+      - intros [H1 _] ; assumption.
+      - cbn ; unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 n1) ; elim (le_lt_dec lgti2 n2) ; intros b a H1 ; try assumption.
+        destruct H1 as [H1 H2].
+        split.
+        + assumption.
+        + apply (IH _ _ _ H2).
     Qed.
 
     Inductive EquivPaths_ter(l1 : list nat)(g1: Graph T)(l2 : list nat)(g2 : Graph T): Prop := 
@@ -676,18 +670,18 @@ Section GeqPermPath.
     Proof.
       induction l1 as [|n1 l1 IH] ;
       intros [|n2 l2] [lab1 [lgti1 sons1]] [lab2 [lgti2 sons2]] ; intros H1 ; apply is_EPt.
-      destruct H1 as [H1 _] ; assumption.
-      inversion H1.
-      inversion H1.
-      revert H1.
-      simpl ; unfold sumbool_rec, sumbool_rect.
-      elim (le_lt_dec lgti1 n1) ;
-      elim (le_lt_dec lgti2 n2) ; intros b a H1.
-      reflexivity.
-      inversion H1.
-      inversion H1.
-      destruct H1 as [H1 H2].
-      apply IH, H2.
+      - destruct H1 as [H1 _] ; assumption.
+      - inversion H1.
+      - inversion H1.
+      - revert H1.
+        cbn ; unfold sumbool_rec, sumbool_rect.
+        elim (le_lt_dec lgti1 n1) ;
+          elim (le_lt_dec lgti2 n2) ; intros b a H1.
+        + reflexivity.
+        + inversion H1.
+        + inversion H1.
+        + destruct H1 as [H1 H2].
+          apply IH, H2.
     Qed.
     
     Definition GeqPermPath (g1 g2: Graph T): Prop := 
@@ -702,14 +696,14 @@ Section GeqPermPath.
     Lemma GeqPermPath_sym : forall g1 g2, GeqPermPath g1 g2 -> GeqPermPath g2 g1.
     Proof.
       intros g1 g2 [H1 H2] ; split.
-      intros l2.
-      destruct (H2 l2) as [l1 H2'].
-      exists l1.
-      apply (EquivPaths_sym _ _ _ _ H2').
-      intros l1. 
-      destruct (H1 l1) as [l2 H1'].
-      exists l2.
-      apply (EquivPaths_sym _ _ _ _ H1').
+      - intros l2.
+        destruct (H2 l2) as [l1 H2'].
+        exists l1.
+        apply (EquivPaths_sym _ _ _ _ H2').
+      - intros l1. 
+        destruct (H1 l1) as [l2 H1'].
+        exists l2.
+        apply (EquivPaths_sym _ _ _ _ H1').
     Qed.
      
     Lemma GeqPermPath_trans : 
@@ -717,18 +711,18 @@ Section GeqPermPath.
     Proof.
       intros g1 g2 g3 H1 H2. 
       split.
-      destruct  H1 as [H1 _] ; destruct H2 as [H2 _].
-      intro l1.
-      destruct (H1 l1) as [l2 H1'].
-      destruct (H2 l2) as [l3 H2'].
-      exists l3.
-      apply (EquivPaths_trans _ _ _ _ _ _ H1' H2').
-      destruct  H1 as [_ H1] ; destruct H2 as [_ H2].
-      intro l3.
-      destruct (H2 l3) as [l2 H2'].
-      destruct (H1 l2) as [l1 H1'].
-      exists l1.
-      apply (EquivPaths_trans _ _ _ _ _ _ H1' H2').
+      - destruct  H1 as [H1 _] ; destruct H2 as [H2 _].
+        intro l1.
+        destruct (H1 l1) as [l2 H1'].
+        destruct (H2 l2) as [l3 H2'].
+        exists l3.
+        apply (EquivPaths_trans _ _ _ _ _ _ H1' H2').
+      - destruct  H1 as [_ H1] ; destruct H2 as [_ H2].
+        intro l3.
+        destruct (H2 l3) as [l2 H2'].
+        destruct (H1 l2) as [l1 H1'].
+        exists l1.
+        apply (EquivPaths_trans _ _ _ _ _ _ H1' H2').
     Qed.
 
     Lemma Geq_GeqPermPath_aux : forall g1 g2, Geq RelT g1 g2 -> 
@@ -737,45 +731,44 @@ Section GeqPermPath.
       intros g1 g2 H l ; exists l ;
       revert g1 g2 H ; induction l as [|t l IH] ; 
       intros _ _ [[lab1 sons1] [lab2 sons2] H1 H2].
-
-      simpl in *|-* .
-      split.
-      assumption.
-      assert (H3 :=imap_ilist_rel Req (@labelM _ RelT) H2).
-      apply (ilist_rel_finer_IlistPerm3 H3).
-      destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2].
-      simpl.
-      unfold sumbool_rec, sumbool_rect.
-      inversion H2 as [h2 H3] ; simpl in h2, H3.
-      elim (le_lt_dec lgti1 t) ; elim (le_lt_dec lgti2 t) ; intros b a.
-      reflexivity.
-      assert (c := le_lt_trans _ _ _ a b).
-      rewrite h2 in c.
-      apply (lt_irrefl _ c).
-      assert (c := le_lt_trans _ _ _ b a).
-      rewrite h2 in c.
-      apply (lt_irrefl _ c).
-      assert (h3 : code_Fin1 b = rewriteFins h2 (code_Fin1 a)).
-      apply decode_Fin_unique.
-      unfold rewriteFins.
-      rewrite <- decode_Fin_match.
-      do 2 rewrite decode_code1_Id.
-      reflexivity.
-      rewrite h3.
-      split.
-      apply (labelM (H3 (code_Fin1 a))).
-      apply (IH _ _ (H3 (code_Fin1 a))).
+      - cbn in *|-* .
+        split.
+        + assumption.
+        + assert (H3 :=imap_ilist_rel Req (@labelM _ RelT) H2).
+          apply (ilist_rel_finer_IlistPerm3 H3).
+      - destruct sons1 as [lgti1 ln1] ; destruct sons2 as [lgti2 ln2].
+        cbn.
+        unfold sumbool_rec, sumbool_rect.
+        inversion H2 as [h2 H3] ; cbn in h2, H3.
+        elim (le_lt_dec lgti1 t) ; elim (le_lt_dec lgti2 t) ; intros b a.
+        + reflexivity.
+        + assert (c := le_lt_trans _ _ _ a b).
+          rewrite h2 in c.
+          apply (lt_irrefl _ c).
+        + assert (c := le_lt_trans _ _ _ b a).
+          rewrite h2 in c.
+          apply (lt_irrefl _ c).
+        + assert (h3 : code_Fin1 b = rewriteFins h2 (code_Fin1 a)).
+          { apply decode_Fin_unique.
+            unfold rewriteFins.
+            rewrite <- decode_Fin_match.
+            do 2 rewrite decode_code1_Id.
+            reflexivity. }
+          rewrite h3.
+          split.
+          * apply (labelM (H3 (code_Fin1 a))).
+          * apply (IH _ _ (H3 (code_Fin1 a))).
     Qed.
 
     Lemma Geq_GeqPermPath : forall g1 g2, Geq RelT g1 g2 -> GeqPermPath g1 g2.
     Proof.
       split.
-      apply (Geq_GeqPermPath_aux H).
-      intro l2.
-      assert (H1 := Geq_GeqPermPath_aux (Geq_sym _ H)).
-      destruct (H1 l2) as [l1 H2].
-      exists l1.
-      apply (EquivPaths_sym _ _ _ _ H2).
+      - apply (Geq_GeqPermPath_aux H).
+      - intro l2.
+        assert (H1 := Geq_GeqPermPath_aux (Geq_sym _ H)).
+        destruct (H1 l2) as [l1 H2].
+        exists l1.
+        apply (EquivPaths_sym _ _ _ _ H2).
     Qed.
 
 End GeqPermPath.

--- a/PermsLists.v
+++ b/PermsLists.v
@@ -18,8 +18,8 @@ Section Tools.
   Lemma length_nil (T: Set)(l: list T) : length l = 0 -> l = nil.
   Proof.
     destruct l as [|t l].
-    reflexivity.
-    intros h ; inversion h.
+    - reflexivity.
+    - intros h ; inversion h.
   Qed.
 
   Lemma nth_nil (T: Set)(d: T)(n: nat) : nth n nil d = d.
@@ -30,34 +30,34 @@ Section Tools.
   Lemma length_skipn  (T: Set)(l: list T)(n: nat) : length (skipn n l) = length l - n.
   Proof.
     revert l ; induction n as [|n IH] ; intros l.
-    apply minus_n_O.
-    destruct l as [|t l].
-    reflexivity.
-    apply IH.
+    - apply minus_n_O.
+    - destruct l as [|t l].
+      + reflexivity.
+      + apply IH.
   Qed.
 
   Lemma firstn_ext(T: Set)(l: list T)(n: nat) : length l <= n -> firstn n l = l.
   Proof.
     revert l ; induction n as [|n IH] ; intros l h.
-    simpl.
-    apply le_n_0_eq, sym_eq in h.
-    apply sym_eq, length_nil, h.
-    destruct l as [|t l].
-    reflexivity.
-    simpl; f_equal ; apply IH.
-    apply le_S_n, h.
+    - cbn.
+      apply le_n_0_eq, sym_eq in h.
+      apply sym_eq, length_nil, h.
+    - destruct l as [|t l].
+      + reflexivity.
+      + cbn; f_equal ; apply IH.
+        apply le_S_n, h.
   Qed.
   
   Lemma skipn_ext(T: Set)(l: list T)(n: nat) : length l <= n -> skipn n l = nil.
   Proof.
     revert l ; induction n as [|n IH] ; intros l h.
-    simpl.
-    apply le_n_0_eq, sym_eq in h.
-    apply length_nil, h.
-    destruct l as [|t l].
-    reflexivity.
-    apply IH.
-    apply le_S_n, h.
+    - cbn.
+      apply le_n_0_eq, sym_eq in h.
+      apply length_nil, h.
+    - destruct l as [|t l].
+      + reflexivity.
+      + apply IH.
+        apply le_S_n, h.
   Qed.
 
 (* alternative by R.M. without extra induction *)
@@ -76,17 +76,17 @@ Section Tools.
     firstn (length l1) (l1 ++ l2) = l1.
   Proof.
     induction l1 as [|t1 l1].
-    reflexivity.
-    simpl.
-    f_equal ; assumption.
+    - reflexivity.
+    - cbn.
+      f_equal ; assumption.
   Qed.
   
   Lemma skipn_app (T: Set)(l1 l2 : list T) : 
     skipn (length l1) (l1 ++ l2) = l2.
   Proof.
     induction l1 as [|t1 l1].
-    reflexivity.
-    assumption.
+    - reflexivity.
+    - assumption.
   Qed.
 
 (* alternative by R.M. without extra induction, same idea as for skipn_ext_ALT *)
@@ -110,13 +110,13 @@ Section Tools.
     n < length l -> l = firstn n l ++ nth n l d :: skipn (S n) l.
   Proof.
     revert l ; induction n as [|n IH] ; intros [|t l] h.
-    inversion h.
-    reflexivity.
-    inversion h.
-    simpl.
-    f_equal.
-    apply IH.
-    apply lt_S_n, h.
+    - inversion h.
+    - reflexivity.
+    - inversion h.
+    - cbn.
+      f_equal.
+      apply IH.
+      apply lt_S_n, h.
   Qed.
 
 (* another exercise by R.M. to use firstn_skipn - not so successful *)
@@ -124,13 +124,13 @@ Section Tools.
     n < length l -> firstn (S n) l = firstn n l ++ nth n l d :: nil.
   Proof.
     revert l ; induction n as [|n IH] ; intros [|t l] h.
-    inversion h.
-    reflexivity.
-    inversion h.
-    simpl.
-    f_equal.
-    apply IH.
-    apply lt_S_n, h.
+    - inversion h.
+    - reflexivity.
+    - inversion h.
+    - cbn.
+      f_equal.
+      apply IH.
+      apply lt_S_n, h.
   Qed.
 
 Lemma firstn_nth_skipn_ALT (T: Set)(d: T)(n: nat)(l: list T) : 
@@ -160,8 +160,8 @@ Section remel.
     intros h.
     unfold remel.
     rewrite app_length, firstn_length, length_skipn, PeanoNat.Nat.min_l, <- plus_Sn_m.
-    apply le_plus_minus_r, lt_le_S, h.
-    apply lt_le_weak, h.
+    - apply le_plus_minus_r, lt_le_S, h.
+    - apply lt_le_weak, h.
   Qed.
   
   Lemma remel_nil (T: Set)(n: nat) : remel n nil = @nil T.
@@ -180,8 +180,8 @@ Section remel.
     intros h.
     unfold remel.
     rewrite firstn_ext, skipn_ext ; try assumption.
-    apply app_nil_r.
-    apply le_S, h.
+    - apply app_nil_r.
+    - apply le_S, h.
   Qed.
   
   Lemma remel_app (T: Set)(t : T)(l1 l2 : list T) : 
@@ -193,7 +193,7 @@ Section remel.
     rewrite (app_assoc l1 (t :: nil) l2 : l1 ++ t :: l2 = (l1 ++ (t :: nil)) ++ l2).
     apply skipn_app_cor.
     rewrite app_length.
-    simpl.
+    cbn.
     rewrite <- plus_n_Sm, <- plus_n_O.
     reflexivity.
   Qed.
@@ -202,31 +202,31 @@ Section remel.
     n' < n -> nth n' (remel n l) d = nth n' l d.
   Proof.
     revert n n' ; induction l as [|t l IH] ; intros n n' H.
-    rewrite remel_nil.
-    reflexivity.
-    destruct n as [|n].
-    inversion H.
-    rewrite remel_S_cons.
-    destruct n' as [|n'].
-    reflexivity.
-    apply IH.
-    apply lt_S_n, H.
+    - rewrite remel_nil.
+      reflexivity.
+    - destruct n as [|n].
+      + inversion H.
+      + rewrite remel_S_cons.
+        destruct n' as [|n'].
+        * reflexivity.
+        * apply IH.
+          apply lt_S_n, H.
   Qed.
   
   Lemma remel_nth2 (T: Set)(d: T)(n n': nat)(l: list T) : 
     n <= n' -> nth n' (remel n l) d = nth (S n') l d.
   Proof.
     revert n n' ; induction l as [|t l IH] ; intros n n' H.
-    rewrite remel_nil, nth_nil, nth_nil.
-    reflexivity.
-    destruct n as [|n].
-    rewrite remel_O_cons.
-    reflexivity.
-    destruct n' as [|n'].
-    inversion H.
-    rewrite remel_S_cons.
-    apply IH.
-    apply le_S_n, H.
+    - rewrite remel_nil, nth_nil, nth_nil.
+      reflexivity.
+    - destruct n as [|n].
+      + rewrite remel_O_cons.
+        reflexivity.
+      + destruct n' as [|n'].
+        * inversion H.
+        * rewrite remel_S_cons.
+          apply IH.
+          apply le_S_n, H.
   Qed.
   
   Section index_from_in_remel.
@@ -236,18 +236,18 @@ Section remel.
       nth n' l d = nth n'' (remel n l) d.
     Proof.
       destruct n' as [|n'].
-      exists 0.
-      rewrite remel_nth1.
-      reflexivity.
-      elim (not_eq _ _ h) ; intros a.
-      inversion a.
-      assumption.
-      elim (lt_eq_lt_dec n (S n')) ; try intros [a|a] ; try intros a ; try contradiction a.
-      exists n'.
-      apply sym_eq, remel_nth2.
-      apply lt_n_Sm_le, a.
-      exists (S n').
-      apply sym_eq, remel_nth1 ; assumption.
+      - exists 0.
+        rewrite remel_nth1.
+        + reflexivity.
+        + elim (not_eq _ _ h) ; intros a.
+          inversion a.
+          assumption.
+      - elim (lt_eq_lt_dec n (S n')) ; try intros [a|a] ; try intros a ; try contradiction a.
+        + exists n'.
+          apply sym_eq, remel_nth2.
+          apply lt_n_Sm_le, a.
+        + exists (S n').
+          apply sym_eq, remel_nth1 ; assumption.
     Qed. 
 
 (* R.M.: notice that the lemma can be put much more uniformly: *)
@@ -255,18 +255,18 @@ Section remel.
       forall (T: Set)(d: T)(l: list T), nth n' l d = nth n'' (remel n l) d.
     Proof.
       destruct n' as [|n'].
-      exists 0; intros.
-      rewrite remel_nth1.
-      reflexivity.
-      elim (not_eq _ _ h) ; intros a.
-      inversion a.
-      assumption.
-      elim (lt_eq_lt_dec n (S n')) ; try intros [a|a] ; try intros a ; try contradiction a.
-      exists n'; intros.
-      apply sym_eq, remel_nth2.
-      apply lt_n_Sm_le, a.
-      exists (S n'); intros.
-      apply sym_eq, remel_nth1 ; assumption.
+      - exists 0; intros.
+        rewrite remel_nth1.
+        + reflexivity.
+        + elim (not_eq _ _ h) ; intros a.
+          * inversion a.
+          * assumption.
+      - elim (lt_eq_lt_dec n (S n')) ; try intros [a|a] ; try intros a ; try contradiction a.
+        + exists n'; intros.
+          apply sym_eq, remel_nth2.
+          apply lt_n_Sm_le, a.
+        + exists (S n'); intros.
+          apply sym_eq, remel_nth1 ; assumption.
     Qed.
 
 (* R.M.: the intention is that index_in_remel h is obtained as the index in remel n l
@@ -274,21 +274,21 @@ Section remel.
     Definition index_in_remel (n n' : nat)(h : n <> n') : nat.
     Proof.
       destruct n' as [|n'].
-      exact 0.
-      elim (lt_eq_lt_dec n (S n')) ; try intros [a|a] ; try intros a ; try contradiction a.
-      exact n'.
-      exact (S n').
+      - exact 0.
+      - elim (lt_eq_lt_dec n (S n')) ; try intros [a|a] ; try intros a ; try contradiction a.
+        + exact n'.
+        + exact (S n').
     Defined.
     
     Lemma index_in_remel_ok1 (n n' : nat)(h : n <> S n') : 
       n < S n' ->  index_in_remel h = n'.
     Proof.
       intros h1.
-      simpl.
+      cbn.
       unfold sumor_rec, sumor_rect.
       elim (lt_eq_lt_dec n (S n')) ; try intros [a|a] ; try intros a ; try contradiction a.
-      reflexivity.
-      apply False_rec, (lt_irrefl _ (lt_trans _ _ _ h1 a)).
+      - reflexivity.
+      - apply False_rec, (lt_irrefl _ (lt_trans _ _ _ h1 a)).
     Qed.
     
     Lemma index_in_remel_ok2 (n n' : nat)(h : n <> n') : 
@@ -296,37 +296,36 @@ Section remel.
     Proof.
       intros h1.
       destruct n' as [|n'].
-      reflexivity.
-      simpl.
-      unfold sumor_rec, sumor_rect.
-      elim (lt_eq_lt_dec n (S n')) ; try intros [a|a] ; try intros a ; try contradiction a.
-      apply False_rec, (lt_irrefl _ (lt_trans _ _ _ h1 a)).
-      reflexivity.
+      - reflexivity.
+      - cbn.
+        unfold sumor_rec, sumor_rect.
+        elim (lt_eq_lt_dec n (S n')) ; try intros [a|a] ; try intros a ; try contradiction a.
+        + apply False_rec, (lt_irrefl _ (lt_trans _ _ _ h1 a)).
+        + reflexivity.
     Qed.
     
     Lemma index_in_remel_ok3 (T: Set)(d: T)(n n' : nat)(l: list T)(h : n <> n') : 
       nth n' l d = nth (index_in_remel h) (remel n l) d.
     Proof.
       elim (not_eq _ _ h) ; intros a.
-      destruct n' as [|n'].
-      inversion a.
-      rewrite index_in_remel_ok1 ; try assumption.
-      apply sym_eq, remel_nth2.
-      apply lt_n_Sm_le, a.
-
-      rewrite index_in_remel_ok2 ; try assumption.
-      apply sym_eq, remel_nth1 ; assumption.
+      - destruct n' as [|n'].
+        + inversion a.
+        + rewrite index_in_remel_ok1 ; try assumption.
+          apply sym_eq, remel_nth2.
+          apply lt_n_Sm_le, a.
+      - rewrite index_in_remel_ok2 ; try assumption.
+        apply sym_eq, remel_nth1 ; assumption.
     Qed. 
     
     Lemma index_in_remel_le (n n' : nat)(h: n <> n') : index_in_remel h <= n'.
     Proof.
       elim (not_eq _ _ h) ; intros a.
-      destruct n' as [|n'].
-      inversion a.
-      rewrite index_in_remel_ok1 ; try assumption.
-      apply le_n_Sn.
-      rewrite index_in_remel_ok2 ; try assumption.
-      apply le_refl.
+      - destruct n' as [|n'].
+        + inversion a.
+        + rewrite index_in_remel_ok1 ; try assumption.
+          apply le_n_Sn.
+      - rewrite index_in_remel_ok2 ; try assumption.
+        apply le_refl.
     Qed.
 
 (* same kind of motivation by R.M. for index_from_remel *)
@@ -334,10 +333,10 @@ Section remel.
       nth n'' l d = nth n' (remel n l) d.
     Proof.
       elim (le_lt_dec n n') ; intros a.
-      exists (S n').
-      apply sym_eq, remel_nth2 ; assumption.
-      exists n'.
-      apply sym_eq, remel_nth1 ; assumption.
+      - exists (S n').
+        apply sym_eq, remel_nth2 ; assumption.
+      - exists n'.
+        apply sym_eq, remel_nth1 ; assumption.
     Qed.
 
 (* R.M.: notice that the lemma can again be put much more uniformly: *)
@@ -356,16 +355,16 @@ Section remel.
     Definition index_from_remel (n n' : nat) : nat.
     Proof.
       elim (le_lt_dec n n') ; intros a.
-      exact (S n').
-      exact n'.
+      - exact (S n').
+      - exact n'.
     Defined.
     
     Lemma ifr_not_eq (n n': nat): index_from_remel n n' <> n.
     Proof.
       unfold index_from_remel, sumbool_rec, sumbool_rect.
       elim (le_lt_dec n n') ; intros a h ; rewrite <- h in a.
-      apply (le_Sn_n _ a).
-      apply (lt_irrefl _ a).
+      - apply (le_Sn_n _ a).
+      - apply (lt_irrefl _ a).
     Qed.
     
     Lemma index_from_remel_ok1 (n n' : nat) : n <= n' -> index_from_remel n n' = S n'.
@@ -373,8 +372,8 @@ Section remel.
       intros h.
       unfold index_from_remel, sumbool_rec, sumbool_rect.
       elim (le_lt_dec n n') ; intros a.
-      reflexivity.
-      apply False_rec, (lt_irrefl _ (le_lt_trans _ _ _ h a)).
+      - reflexivity.
+      - apply False_rec, (lt_irrefl _ (le_lt_trans _ _ _ h a)).
     Qed.
     
     Lemma index_from_remel_ok2 (n n' : nat) : n' < n -> index_from_remel n n' = n'.
@@ -382,63 +381,61 @@ Section remel.
       intros h.
       unfold index_from_remel, sumbool_rec, sumbool_rect.
       elim (le_lt_dec n n') ; intros a.
-      apply False_rec, (lt_irrefl _ (le_lt_trans _ _ _ a h)).
-      reflexivity.
+      - apply False_rec, (lt_irrefl _ (le_lt_trans _ _ _ a h)).
+      - reflexivity.
     Qed.
     
     Lemma index_from_remel_ok3 (T: Set)(d: T)(n n' : nat)(l: list T): 
       nth (index_from_remel n n') l d = nth n' (remel n l) d.
     Proof.
       elim (le_lt_dec n n') ; intros a.
-      rewrite index_from_remel_ok1 ; try assumption.
-      apply sym_eq, remel_nth2 ; assumption.
-      rewrite index_from_remel_ok2 ; try assumption.
-      apply sym_eq, remel_nth1 ; assumption.
+      - rewrite index_from_remel_ok1 ; try assumption.
+        apply sym_eq, remel_nth2 ; assumption.
+      - rewrite index_from_remel_ok2 ; try assumption.
+        apply sym_eq, remel_nth1 ; assumption.
     Qed. 
     
     Lemma index_from_remel_le (n n' : nat): n' <= index_from_remel n n'.
     Proof.
       elim (le_lt_dec n n') ; intros a.
-      rewrite index_from_remel_ok1 ; try assumption.
-      apply le_n_Sn.
-      rewrite index_from_remel_ok2 ; try assumption.
-      apply le_refl.
+      - rewrite index_from_remel_ok1 ; try assumption.
+        apply le_n_Sn.
+      - rewrite index_from_remel_ok2 ; try assumption.
+        apply le_refl.
     Qed.
     
     Lemma index_from_remel_le2 (n n' : nat): index_from_remel n n' <= S n'.
     Proof.
       elim (le_lt_dec n n') ; intros a.
-      rewrite index_from_remel_ok1 ; try assumption.
-      apply le_refl.
-      rewrite index_from_remel_ok2 ; try assumption.
-      apply le_n_Sn.
+      - rewrite index_from_remel_ok1 ; try assumption.
+        apply le_refl.
+      - rewrite index_from_remel_ok2 ; try assumption.
+        apply le_n_Sn.
     Qed.
     
     Lemma index_in_from_remel (n n' : nat)(h: n <> index_from_remel n n') : 
       index_in_remel h = n'.
     Proof.
       revert h ; elim (le_lt_dec n n') ; intros a.
-      rewrite index_from_remel_ok1 ; try assumption.
-      intros h.
-      apply index_in_remel_ok1, le_lt_n_Sm, a.
-      
-      rewrite index_from_remel_ok2 ; try assumption.
-      intros h.
-      apply index_in_remel_ok2, a.
+      - rewrite index_from_remel_ok1 ; try assumption.
+        intros h.
+        apply index_in_remel_ok1, le_lt_n_Sm, a.
+      - rewrite index_from_remel_ok2 ; try assumption.
+        intros h.
+        apply index_in_remel_ok2, a.
     Qed.
     
     Lemma index_from_in_remel (n n' : nat)(h: n <> n') : 
       index_from_remel n (index_in_remel h) = n'.
     Proof.
       elim (not_eq _ _ h) ; intros a.
-      destruct n' as [|n'].
-      inversion a.
-      rewrite index_in_remel_ok1, index_from_remel_ok1 ; try assumption.
-      reflexivity.
-      apply lt_n_Sm_le, a.
-      
-      rewrite index_in_remel_ok2, index_from_remel_ok2 ; try assumption.
-      reflexivity.
+      - destruct n' as [|n'].
+        + inversion a.
+        + rewrite index_in_remel_ok1, index_from_remel_ok1 ; try assumption.
+          * reflexivity.
+          * apply lt_n_Sm_le, a.
+      - rewrite index_in_remel_ok2, index_from_remel_ok2 ; try assumption.
+        reflexivity.
     Qed.
     
     Lemma iir_length_remel (T: Set)(n n': nat)(h : n <> n')(l: list T) : 
@@ -446,31 +443,30 @@ Section remel.
     Proof.
       intros h1.
       elim (not_eq _ _ h) ; intros a.
-      apply lt_S_n.
-      destruct n' as [|n'].
-      inversion a.
-      rewrite length_remel, index_in_remel_ok1 ; try assumption.
-      apply (lt_trans _ _ _ a h1).
-      
-      elim (le_lt_dec (length l) n) ; intros b.
-      rewrite remel_ext ; try assumption.
-      apply (le_lt_trans _ _ _ (index_in_remel_le h) h1).
-      apply lt_S_n.
-      rewrite length_remel, index_in_remel_ok2 ; try assumption.
-      apply lt_le_S in a.
-      apply (le_lt_trans _ _ _ a b).
+      - apply lt_S_n.
+        destruct n' as [|n'].
+        + inversion a.
+        + rewrite length_remel, index_in_remel_ok1 ; try assumption.
+          apply (lt_trans _ _ _ a h1).
+      - elim (le_lt_dec (length l) n) ; intros b.
+        + rewrite remel_ext ; try assumption.
+          apply (le_lt_trans _ _ _ (index_in_remel_le h) h1).
+        + apply lt_S_n.
+          rewrite length_remel, index_in_remel_ok2 ; try assumption.
+          apply lt_le_S in a.
+          apply (le_lt_trans _ _ _ a b).
     Qed.
     
     Lemma index_in_remel_proof_irrel (n n': nat) (a a' : n <> n') : 
       index_in_remel a = index_in_remel a'.
     Proof.
       elim (not_eq _ _ a) ; intros b.
-      destruct n' as [|n'].
-      inversion b.
-      rewrite index_in_remel_ok1, index_in_remel_ok1 ; try assumption.
-      reflexivity.
-      rewrite index_in_remel_ok2, index_in_remel_ok2 ; try assumption.
-      reflexivity.
+      - destruct n' as [|n'].
+        + inversion b.
+        + rewrite index_in_remel_ok1, index_in_remel_ok1 ; try assumption.
+          reflexivity.
+      - rewrite index_in_remel_ok2, index_in_remel_ok2 ; try assumption.
+        reflexivity.
     Qed.
 
   End index_from_in_remel.
@@ -479,35 +475,35 @@ Section remel.
     remel n' (remel n l) = remel n (remel (S n') l).
   Proof.
     revert n n' h ; induction l as [|t l IH] ; intros n n' h.
-    repeat rewrite remel_nil.
-    reflexivity.
-    destruct n as [|n].
-    rewrite remel_O_cons, remel_S_cons, remel_O_cons.
-    reflexivity.
-    destruct n' as [|n'].
-    apply lt_S_n in h ; inversion h.
-    repeat rewrite remel_S_cons.
-    f_equal.
-    apply IH.
-    apply lt_S_n, h.
+    - repeat rewrite remel_nil.
+      reflexivity.
+    - destruct n as [|n].
+      + rewrite remel_O_cons, remel_S_cons, remel_O_cons.
+        reflexivity.
+      + destruct n' as [|n'].
+        * apply lt_S_n in h ; inversion h.
+        * repeat rewrite remel_S_cons.
+          f_equal.
+          apply IH.
+          apply lt_S_n, h.
   Qed.
 
   Lemma remel_interchange_aux1_elemwise_aux  (n n' n'': nat)(h : n < S n') :
     index_from_remel n (index_from_remel n' n'') = index_from_remel (S n') (index_from_remel n n'').
   Proof.
     elim (le_lt_dec n' n'') ; intros a.
-    assert (b := le_trans _ _ _ (lt_n_Sm_le _ _ h) a).
-    repeat  rewrite index_from_remel_ok1 ; try assumption.
-    reflexivity.
-    apply le_n_S, a.
-    apply (le_trans _ _ _ b (le_n_Sn n'')).
-    rewrite (index_from_remel_ok2 a), (@index_from_remel_ok2 (S n') _).
-    reflexivity.
-    elim (le_lt_dec n n'') ; intros b.
-    rewrite (index_from_remel_ok1 b).
-    apply lt_n_S, a.
-    rewrite (index_from_remel_ok2 b).
-    apply (lt_trans _ _ _ b h).
+    - assert (b := le_trans _ _ _ (lt_n_Sm_le _ _ h) a).
+      repeat rewrite index_from_remel_ok1 ; try assumption.
+      + reflexivity.
+      + apply le_n_S, a.
+      + apply (le_trans _ _ _ b (le_n_Sn n'')).
+    - rewrite (index_from_remel_ok2 a), (@index_from_remel_ok2 (S n') _).
+      + reflexivity.
+      + elim (le_lt_dec n n'') ; intros b.
+        * rewrite (index_from_remel_ok1 b).
+          apply lt_n_S, a.
+        * rewrite (index_from_remel_ok2 b).
+          apply (lt_trans _ _ _ b h).
   Qed.
 
   Lemma remel_interchange_aux1_elemwise  (T: Set)(n n' n'': nat)(h : n < S n')(l: list T)(d: T) : 
@@ -515,8 +511,8 @@ Section remel.
   Proof.
     do 4 rewrite <- index_from_remel_ok3.
     rewrite remel_interchange_aux1_elemwise_aux.
-    reflexivity.
-    assumption.
+    - reflexivity.
+    - assumption.
   Qed.
     
 
@@ -546,10 +542,10 @@ At least, the above lemma is a consequence of remel_interchange_aux1: *)
   Lemma ntruelength (n: nat): length(ntrue n) = n.
   Proof.
     induction n.
-    reflexivity.
-    simpl.
-    rewrite IHn.
-    reflexivity.
+    - reflexivity.
+    - cbn.
+      rewrite IHn.
+      reflexivity.
   Qed.
 
   Lemma ntruentheq (n: nat): nth n (ntrue n) false = false.
@@ -563,13 +559,13 @@ At least, the above lemma is a consequence of remel_interchange_aux1: *)
   Proof.
     intro H.
     revert m H; induction n; intros.
-    inversion H.
-    destruct m.
-    reflexivity.
-    simpl.
-    apply IHn.
-    apply lt_S_n.
-    assumption.
+    - inversion H.
+    - destruct m.
+      + reflexivity.
+      + cbn.
+        apply IHn.
+        apply lt_S_n.
+        assumption.
   Qed.
 
   Lemma from_all_lists_to_indices (m n: nat): 
@@ -577,17 +573,17 @@ At least, the above lemma is a consequence of remel_interchange_aux1: *)
   Proof.
     intro H.
     destruct (lt_eq_lt_dec m n) as [[h1|h2] | h3].
-    assert (Hyp := H false (ntrue n)).
-    clear H.
-    rewrite ntruentheq in Hyp.
-    rewrite (ntruenthlt h1) in Hyp.
-    inversion Hyp.
-    assumption.
-    assert (Hyp := H false (ntrue m)).
-    clear H.
-    rewrite ntruentheq in Hyp.
-    rewrite (ntruenthlt h3) in Hyp.
-    inversion Hyp.
+    - assert (Hyp := H false (ntrue n)).
+      clear H.
+      rewrite ntruentheq in Hyp.
+      rewrite (ntruenthlt h1) in Hyp.
+      inversion Hyp.
+    - assumption.
+    - assert (Hyp := H false (ntrue m)).
+      clear H.
+      rewrite ntruentheq in Hyp.
+      rewrite (ntruenthlt h3) in Hyp.
+      inversion Hyp.
   Qed.
 
   Lemma remel_interchange_aux1_elemwise_aux_ALT  (n n' n'': nat)(h : n < S n') :
@@ -598,8 +594,8 @@ At least, the above lemma is a consequence of remel_interchange_aux1: *)
     intros.
     do 4 rewrite index_from_remel_ok3.
     rewrite remel_interchange_aux1.
-    reflexivity.
-    assumption.
+    - reflexivity.
+    - assumption.
   Qed.
 
 (* end of detour by R.M. *)
@@ -615,14 +611,14 @@ At least, the above lemma is a consequence of remel_interchange_aux1: *)
     remel (index_in_remel (not_eq_sym h)) (remel n' l).
   Proof.
     elim (not_eq _ _ h) ; intros a.
-    destruct n' as [|n'].
-    inversion a.
-    rewrite (index_in_remel_ok1 h), (index_in_remel_ok2 (not_eq_sym h)); try assumption.
-    apply remel_interchange_aux1 ; assumption.
-    destruct n as [|n].
-    inversion a.
-    rewrite (index_in_remel_ok2 h), (index_in_remel_ok1 (not_eq_sym h)); try assumption.
-    apply remel_interchange_aux2; assumption.
+    - destruct n' as [|n'].
+      + inversion a.
+      + rewrite (index_in_remel_ok1 h), (index_in_remel_ok2 (not_eq_sym h)); try assumption.
+        apply remel_interchange_aux1 ; assumption.
+    - destruct n as [|n].
+      + inversion a.
+      + rewrite (index_in_remel_ok2 h), (index_in_remel_ok1 (not_eq_sym h)); try assumption.
+        apply remel_interchange_aux2; assumption.
   Qed.
 
 (* R.M.: again see what this means element-wise: *)
@@ -643,16 +639,16 @@ Lemma remel_interchange_elemwise_aux_ALT (n n' n'': nat)(h : n <> n') :
     index_from_remel n' (index_from_remel (index_in_remel (not_eq_sym h)) n'').
   Proof.
     elim (not_eq _ _ h) ; intros a.
-    destruct n' as [|n'].
-    inversion a.
-    rewrite (index_in_remel_ok1 h), (index_in_remel_ok2 (not_eq_sym h)); try assumption.
-    apply remel_interchange_aux1_elemwise_aux; assumption.
-    destruct n as [|n].
-    inversion a.
-    rewrite (index_in_remel_ok2 h), (index_in_remel_ok1 (not_eq_sym h)); try assumption.
-    rewrite <- remel_interchange_aux1_elemwise_aux.
-    reflexivity.
-    assumption.
+    - destruct n' as [|n'].
+      + inversion a.
+      + rewrite (index_in_remel_ok1 h), (index_in_remel_ok2 (not_eq_sym h)); try assumption.
+        apply remel_interchange_aux1_elemwise_aux; assumption.
+    - destruct n as [|n].
+      + inversion a.
+      + rewrite (index_in_remel_ok2 h), (index_in_remel_ok1 (not_eq_sym h)); try assumption.
+        rewrite <- remel_interchange_aux1_elemwise_aux.
+        * reflexivity.
+        * assumption.
   Qed.
 (* end of detour by R.M. *)
 
@@ -677,19 +673,19 @@ Section Permutations_definitions.
     permut1 R l1 l2 -> length l1 = length l2.
   Proof.
     intro H ; induction H as [|n1 n2 t l1 l2 H1 H2 H3 H4 IH].
-    reflexivity.
-    rewrite <- (length_remel l1 H1), <- (length_remel l2 H2), IH.
-    reflexivity.
+    - reflexivity.
+    - rewrite <- (length_remel l1 H1), <- (length_remel l2 H2), IH.
+      reflexivity.
   Qed.
   
   Lemma permut1_refl (T: Set)(R: relation T)(Rrefl: Reflexive R)(l : list T) : 
     permut1 R l l.
   Proof.
     induction l as [|t l IH].
-    apply P1nil.
-    apply (@P1cons _ _ 0 0 t) ; try apply lt_0_Sn.
-    reflexivity.
-    assumption.
+    - apply P1nil.
+    - apply (@P1cons _ _ 0 0 t) ; try apply lt_0_Sn.
+      + reflexivity.
+      + assumption.
   Qed. 
   
   Lemma permut1_sym (T: Set)(R: relation T)(Rsym: Symmetric R)(l1 l2 : list T) : 
@@ -697,10 +693,10 @@ Section Permutations_definitions.
   Proof.
     intros H.
     induction H as [| n1 n2 t l1 l2 H1 H2 H3 H4 IH].
-    apply P1nil.
-    apply (P1cons t _ _ H2 H1).
-    symmetry ; assumption.
-    apply IH.
+    - apply P1nil.
+    - apply (P1cons t _ _ H2 H1).
+      + symmetry ; assumption.
+      + apply IH.
   Qed.
   
   (* Definition corresponding to IlistPerm4 *)                     
@@ -714,9 +710,9 @@ Section Permutations_definitions.
   Lemma permut2_nil (T: Set)(R: relation T): permut2 R nil nil.
   Proof.
     apply P2intro.
-    reflexivity.
-    intros n t H.
-    inversion H.
+    - reflexivity.
+    - intros n t H.
+      inversion H.
   Qed.
   
   Lemma permut2_length (T: Set)(R: relation T)(l1 l2 : list T): 
@@ -737,11 +733,11 @@ Section Permutations_definitions.
   Proof.
     intros H1 H2 H3.
     elim (le_lt_dec (length l2) n2) ; intros a.
-    assert (H4 := eq_S _ _ (permut2_length H3)).
-    rewrite (remel_ext l2 a), length_remel, H1 in H4 ; try assumption.
-    contradict H4.
-    apply n_Sn.
-    assumption.
+    - assert (H4 := eq_S _ _ (permut2_length H3)).
+      rewrite (remel_ext l2 a), length_remel, H1 in H4 ; try assumption.
+      contradict H4.
+      apply n_Sn.
+    - assumption.
   Qed.
     
   Lemma permut2_ind_better: forall (T : Set)(RelT : relation T)(P: list T -> list T -> Prop),
@@ -769,22 +765,22 @@ Section Permutations_definitions.
     assert (h1 := h).
     induction h as [l1 l2 H1 H2] using permut2_ind_better.
     apply P2intro.
-    simpl ; f_equal ; assumption.
-    intros [|n1] d HL.
-    exists 0.
-    split.
-    reflexivity.
-    do 2 rewrite remel_O_cons.
-    assumption.
-    simpl in HL.
-    apply lt_S_n in HL.
-    destruct (H2 n1 d HL) as [n2 H] ; clear H2.
-    exists (S n2).
-    destruct H as [H3 [H4 H5]].
-    split.
-    assumption.
-    do 2 rewrite remel_S_cons.
-    apply H5, H4.
+    - cbn ; f_equal ; assumption.
+    - intros [|n1] d HL.
+      + exists 0.
+        split.
+        * reflexivity.
+        * do 2 rewrite remel_O_cons.
+          assumption.
+      + cbn in HL.
+        apply lt_S_n in HL.
+        destruct (H2 n1 d HL) as [n2 H] ; clear H2.
+        exists (S n2).
+        destruct H as [H3 [H4 H5]].
+        split.
+        * assumption.
+        * do 2 rewrite remel_S_cons.
+          apply H5, H4.
   Qed.
   
 (* the proof without the equivalence between all the notions *)
@@ -792,8 +788,8 @@ Section Permutations_definitions.
     permut2 R l l.
   Proof.
     induction l as [|t l IH].
-    apply permut2_nil.
-    apply permut2_cons_FYI ; assumption.
+    - apply permut2_nil.
+    - apply permut2_cons_FYI ; assumption.
   Qed. 
   
   Lemma permut2_trans (T: Set)(R: relation T)(Rtrans: Transitive R)(l1 l2 l3: list T) : 
@@ -803,18 +799,18 @@ Section Permutations_definitions.
     revert l1 H1; induction H3 as [l2 l3 H3 H4] using permut2_ind_better ; intros l1 H1.
     induction H1 as [l1 l2 H1 H2] using permut2_ind_better.
     apply P2intro.
-    transitivity (length l2) ; assumption.
-    intros n1 t HL.
-    destruct (H2 n1 t HL) as [n2 H5].
-    destruct H5 as [H7 [H8 H9]]. 
-    assert (HL' := permut2_wellformed l1 l2 n2 H1 HL H8).
-    destruct (H4 n2 t HL') as [n3 H6].
-    exists n3.
-    destruct H6 as [H10 [H11 H12]].
-    split.
-    transitivity (nth n2 l2 t) ; assumption.
-    apply H12.
-    assumption.
+    - transitivity (length l2) ; assumption.
+    - intros n1 t HL.
+      destruct (H2 n1 t HL) as [n2 H5].
+      destruct H5 as [H7 [H8 H9]]. 
+      assert (HL' := permut2_wellformed l1 l2 n2 H1 HL H8).
+      destruct (H4 n2 t HL') as [n3 H6].
+      exists n3.
+      destruct H6 as [H10 [H11 H12]].
+      split.
+      + transitivity (nth n2 l2 t) ; assumption.
+      + apply H12.
+        assumption.
   Qed.
 
 End Permutations_definitions.
@@ -825,15 +821,15 @@ Section Proofs_of_equivalence.
     permut R l1 l2 -> permut1 R l1 l2.
   Proof.
     intros H ; induction H as [|a b l l1 l2 H1 H2 IH].
-    apply P1nil.
-    apply (@P1cons _ _ 0 (length l1) a) ; try apply lt_O_Sn.
-    rewrite app_length.
-    rewrite <- (plus_0_r (length l1)) at 1.
-    apply plus_lt_compat_l, lt_O_Sn.
-    rewrite app_nth2, minus_diag ; try apply le_refl.
-    assumption.
-    rewrite remel_app, remel_O_cons.
-    exact IH.
+    - apply P1nil.
+    - apply (@P1cons _ _ 0 (length l1) a) ; try apply lt_O_Sn.
+      + rewrite app_length.
+        rewrite <- (plus_0_r (length l1)) at 1.
+        apply plus_lt_compat_l, lt_O_Sn.
+      + rewrite app_nth2, minus_diag ; try apply le_refl.
+        assumption.
+      + rewrite remel_app, remel_O_cons.
+        exact IH.
   Qed.
 
 (* not necessary since it follows from the lemmas immediately before and after it *)
@@ -842,14 +838,14 @@ Section Proofs_of_equivalence.
   Proof.
     intros H ; induction H as [l1 l2 H1 IH] using permut2_ind_better.
     destruct l1 as [|t1 l1] ; destruct l2 as [|t2 l2].
-    apply P1nil.
-    inversion H1.
-    inversion H1.
-    destruct (IH 0 t1 (lt_O_Sn _ : 0 < length (t1 :: l1))) as [n2 H].
-    destruct H as [H2 [H3 H4]] ; clear IH.
-    apply (@P1cons _ _ 0 n2 t1) ; try assumption.
-    apply lt_O_Sn.
-    apply (permut2_wellformed _ _ n2 H1 (lt_O_Sn _ : 0 < length (t1 :: l1)) H3).
+    - apply P1nil.
+    - inversion H1.
+    - inversion H1.
+    - destruct (IH 0 t1 (lt_O_Sn _ : 0 < length (t1 :: l1))) as [n2 H].
+      destruct H as [H2 [H3 H4]] ; clear IH.
+      apply (@P1cons _ _ 0 n2 t1) ; try assumption.
+      + apply lt_O_Sn.
+      + apply (permut2_wellformed _ _ n2 H1 (lt_O_Sn _ : 0 < length (t1 :: l1)) H3).
   Qed.
 
   Lemma permut2_permut (T: Set)(R: relation T)(l1 l2 : list T) : 
@@ -857,15 +853,15 @@ Section Proofs_of_equivalence.
   Proof.
     intros H ; induction H as [l1 l2 H1 IH] using permut2_ind_better.
     destruct l1 as [|t1 l1] ; destruct l2 as [|t2 l2].
-    apply Pnil.
-    inversion H1.
-    inversion H1.
-    destruct (IH 0 t1 (lt_O_Sn _ : 0 < length (t1 :: l1))) as [n2 H]; clear IH.
-    destruct H as [H2 [H3 H4]].
-    assert (a: n2 < length (t2 :: l2)).
-    apply (permut2_wellformed _ _ n2 H1 (lt_O_Sn _ : 0 < length (t1 :: l1)) H3).
-    rewrite (firstn_nth_skipn t1 (t2 :: l2) a).
-    apply Pcons ; assumption.
+    - apply Pnil.
+    - inversion H1.
+    - inversion H1.
+    - destruct (IH 0 t1 (lt_O_Sn _ : 0 < length (t1 :: l1))) as [n2 H]; clear IH.
+      destruct H as [H2 [H3 H4]].
+      assert (a: n2 < length (t2 :: l2)).
+      { apply (permut2_wellformed _ _ n2 H1 (lt_O_Sn _ : 0 < length (t1 :: l1)) H3). }
+      rewrite (firstn_nth_skipn t1 (t2 :: l2) a).
+      apply Pcons ; assumption.
   Qed.
 
   Lemma permut1_exists_rec (T: Set)(R: relation T)(l1 l2 : list T) : 
@@ -873,33 +869,29 @@ Section Proofs_of_equivalence.
     R (nth n1 l1 d) (nth n2 l2 d) /\ permut1 R (remel n1 l1) (remel n2 l2).
   Proof.
     intros H ; induction H as [|n1 n2 t l1 l2 H1 H2 H3 H4 IH].
-    (* empty list *)
-    intros n1 d HL.
-    inversion HL.
-    
-    (* non empty list *)
-    intros n1' d HL.
-    rewrite (nth_indep _ t d H1), (nth_indep _ t d H2) in H3.
-    elim (eq_nat_dec n1 n1') ; intros a.
-    (* n1 = n1'*)
-    rewrite <- a ; clear a ; exists n2 ; split ; assumption.
-    
-    (* n1 <> n1'*)
-    destruct (IH (index_in_remel a) d (iir_length_remel a _ HL)) as [n2'IH H5]; clear IH.
-    exists (index_from_remel n2 n2'IH).
-    destruct H5 as [H6 H7].
-    split.
-    rewrite <- index_in_remel_ok3, <- index_from_remel_ok3 in H6.
-    assumption.
-     
-    apply (P1cons d _ _ (iir_length_remel (not_eq_sym a) _ H1)
-                        (iir_length_remel (ifr_not_eq _) _ H2)).
-    do 2 rewrite <- index_in_remel_ok3.
-    assumption.
-    rewrite (remel_interchange _ l1), (remel_interchange _ l2).
-    
-    rewrite (index_in_remel_proof_irrel _ a), (index_in_from_remel _ (not_eq_sym _)).
-    assumption.
+    - (* empty list *)
+      intros n1 d HL.
+      inversion HL.
+    - (* non empty list *)
+      intros n1' d HL.
+      rewrite (nth_indep _ t d H1), (nth_indep _ t d H2) in H3.
+      elim (eq_nat_dec n1 n1') ; intros a.
+      + (* n1 = n1'*)
+        rewrite <- a ; clear a ; exists n2 ; split ; assumption.
+      + (* n1 <> n1'*)
+        destruct (IH (index_in_remel a) d (iir_length_remel a _ HL)) as [n2'IH H5]; clear IH.
+        exists (index_from_remel n2 n2'IH).
+        destruct H5 as [H6 H7].
+        split.
+        * rewrite <- index_in_remel_ok3, <- index_from_remel_ok3 in H6.
+          assumption.
+        * apply (P1cons d _ _ (iir_length_remel (not_eq_sym a) _ H1)
+                              (iir_length_remel (ifr_not_eq _) _ H2)).
+          -- do 2 rewrite <- index_in_remel_ok3.
+             assumption.
+          -- rewrite (remel_interchange _ l1), (remel_interchange _ l2).
+             rewrite (index_in_remel_proof_irrel _ a), (index_in_from_remel _ (not_eq_sym _)).
+             assumption.
   Qed.
   
   Lemma permut1_permut2 (T: Set)(R: relation T)(l1 l2 : list T) : 
@@ -907,21 +899,21 @@ Section Proofs_of_equivalence.
   Proof.
     remember (length l1) as n.
     revert l1 l2 Heqn ; induction n as [|n IH] ; intros l1 l2 Heqn H.
-    rewrite (length_nil _ (sym_eq Heqn)), 
-    (length_nil _ (sym_eq (trans_eq Heqn (permut1_length H)))).
-    apply permut2_nil.
-    assert (H1 := permut1_exists_rec H).
-    apply P2intro.
-    apply (permut1_length H).
-    intros n1 t HL.
-    destruct (H1 n1 t HL) as [n2 H2]; clear H1.
-    exists n2.
-    destruct H2 as [H4 H5].
-    split.
-    assumption.
-    apply IH ; try assumption.
-    apply eq_add_S.
-    rewrite length_remel ; assumption.
+    - rewrite (length_nil _ (sym_eq Heqn)), 
+        (length_nil _ (sym_eq (trans_eq Heqn (permut1_length H)))).
+      apply permut2_nil.
+    - assert (H1 := permut1_exists_rec H).
+      apply P2intro.
+      + apply (permut1_length H).
+      + intros n1 t HL.
+        destruct (H1 n1 t HL) as [n2 H2]; clear H1.
+        exists n2.
+        destruct H2 as [H4 H5].
+        split.
+        * assumption.
+        * apply IH ; try assumption.
+          apply eq_add_S.
+          rewrite length_remel ; assumption.
   Qed.
   
 End Proofs_of_equivalence.
@@ -974,8 +966,8 @@ Section Equivalence_relations.
     apply permut1_permut2, permut_permut1.
     change (t::l2) with (nil ++ t::l2). 
     apply Pcons.
-    reflexivity.
-    assumption.
+    - reflexivity.
+    - assumption.
   Qed.    
 
 End Equivalence_relations.

--- a/Tools.v
+++ b/Tools.v
@@ -88,7 +88,7 @@ Section Tools_lists.
       (* definition of the maximum of a list of natural numbers *)
       Definition max_list_nat (l: list nat) : nat := max_list_nat_aux 0 l.
       
-      Fixpoint max_list_nat' (l: list nat): nat := 
+      Definition max_list_nat' (l: list nat): nat := 
         fold_left max l 0.
         
       Lemma max_list_nat_max_list_nat': forall (l: list nat), max_list_nat l = max_list_nat' l.

--- a/Tools.v
+++ b/Tools.v
@@ -22,16 +22,16 @@ Section Tools_lists.
     (forall n, nth n l1 d = nth n l2 d) -> l1 = l2.
   Proof.
     revert l2.
-    induction l1 as [|t1 l1 IH] ; intros l2 H1 H2 ;destruct l2 as [|t2 l2].
-    reflexivity.
-    inversion H1.
-    inversion H1.
-    f_equal.
-    apply (H2 0).
-    apply IH.
-    apply eq_add_S, H1.
-    intros n.
-    apply (H2 (S n)).
+    induction l1 as [|t1 l1 IH]; intros l2 H1 H2; destruct l2 as [|t2 l2].
+    - reflexivity.
+    - inversion H1.
+    - inversion H1.
+    - f_equal.
+      + apply (H2 0).
+      + apply IH.
+        * apply eq_add_S, H1.
+        * intros n.
+          apply (H2 (S n)).
   Qed.
   
   
@@ -40,26 +40,26 @@ Section Tools_lists.
     (forall n d, nth n l1 d = nth n l2 d) -> l1 = l2.
   Proof.
     intros H1 H2.
-    destruct l1 as [|t1 l1] ;destruct l2 as [|t2 l2].
-    reflexivity.
-    inversion H1.
-    inversion H1.
-    apply (eq_nth _ _ t1).
-    assumption.
-    intros n.
-    apply (H2 n t1).
+    destruct l1 as [|t1 l1]; destruct l2 as [|t2 l2].
+    - reflexivity.
+    - inversion H1.
+    - inversion H1.
+    - apply (eq_nth _ _ t1).
+      + assumption.
+      + intros n.
+        apply (H2 n t1).
   Qed.
   
   Lemma nth_default (T: Set)(l: list T)(n: nat)(d: T) : length l <= n -> nth n l d = d.
   Proof.
-    revert l ; induction n as [|n IH] ; destruct l as [|t l] ; intros H.
-    reflexivity.
-    inversion H.
-    reflexivity.
-    simpl.
-    apply IH.
-    apply le_S_n.
-    assumption.
+    revert l; induction n as [|n IH]; destruct l as [|t l]; intros H.
+    - reflexivity.
+    - inversion H.
+    - reflexivity.
+    - simpl.
+      apply IH.
+      apply le_S_n.
+      assumption.
   Qed.
   
   Lemma eq_nth_cor' (T: Set)(l1 l2 : list T): 
@@ -67,14 +67,14 @@ Section Tools_lists.
     (forall n d,  n < length l1 -> nth n l1 d = nth n l2 d) -> l1 = l2.
   Proof.
     intros h1 h2.
-    apply eq_nth_cor ; try assumption.
+    apply eq_nth_cor; try assumption.
     intros n d.
     elim (le_lt_dec (length l1) n); intros a.
-    rewrite nth_default, nth_default ; try assumption.
-    reflexivity.
-    rewrite <- h1 ; assumption.
-    apply h2.
-    assumption.
+    - rewrite nth_default, nth_default ; try assumption.
+      + reflexivity.
+      + rewrite <- h1 ; assumption.
+    - apply h2.
+      assumption.
   Qed.
   
   Section MaxListNat.
@@ -94,10 +94,10 @@ Section Tools_lists.
       Lemma max_list_nat_max_list_nat': forall (l: list nat), max_list_nat l = max_list_nat' l.
       Proof.
         destruct l as [|t q].
-        reflexivity.
-        revert t ; induction q as [|t' q' IH]; intros t.
-        reflexivity.
-        apply IH.
+        - reflexivity.
+        - revert t ; induction q as [|t' q' IH]; intros t.
+          + reflexivity.
+          + apply IH.
       Qed.
       
       (* properties on max_list_nat *)
@@ -107,11 +107,11 @@ Section Tools_lists.
         intros n m l.
         revert n m ; 
         induction l as [|t l IHl] ; intros n m.
-        reflexivity.
-        simpl.
-        do 2 rewrite IHl.
-        rewrite Nat.max_assoc.
-        reflexivity.
+        - reflexivity.
+        - cbn.
+          do 2 rewrite IHl.
+          rewrite Nat.max_assoc.
+          reflexivity.
       Qed.
 
       Lemma max_list_cons: forall (t: nat)(l: list nat),
@@ -119,11 +119,11 @@ Section Tools_lists.
       Proof.
         intros t l.
         destruct l as [| h l].
-        destruct t as [|t] ;
-        reflexivity.
-        destruct t as [|t].
-        reflexivity.
-        apply max_list_nat_aux_max.
+        - destruct t as [|t] ;
+            reflexivity.
+        - destruct t as [|t].
+          + reflexivity.
+          + apply max_list_nat_aux_max.
       Qed.
       
 
@@ -137,14 +137,14 @@ Section Tools_lists.
       Proof.
         induction l as [|h t] ;
         intros x H.
-        inversion H.
-        rewrite max_list_cons.
-        destruct H as [e | H].
-        rewrite <- e.
-        apply Nat.le_max_l.
-        assert (H1: max_list_nat t <= max h (max_list_nat t)).
-        apply Nat.le_max_r.
-        apply (le_trans _ _ _ (IHt x H) H1).
+        - inversion H.
+        - rewrite max_list_cons.
+          destruct H as [e | H].
+          + rewrite <- e.
+            apply Nat.le_max_l.
+          + assert (H1: max_list_nat t <= max h (max_list_nat t)).
+            { apply Nat.le_max_r. }
+            apply (le_trans _ _ _ (IHt x H) H1).
       Qed.
       
       Lemma exists_max_list_nat: forall l: list nat, 
@@ -168,37 +168,37 @@ Section Tools_lists.
     (x: X)(l: list X): In x l -> S (length (remove' eq_dec x l)) = length l.
   Proof.
     induction l as [|t l IH] ; intro H.
-    inversion H.
-    destruct H as [H|H].
-    rewrite H.
-    simpl.
-    elim (eq_dec x x) ; intros a.
-    reflexivity.
-    contradiction (eq_refl x).
-    simpl.
-    elim (eq_dec x t) ; intros a.
-    reflexivity.
-    simpl.
-    rewrite (IH H).
-    reflexivity.
+    - inversion H.
+    - destruct H as [H|H].
+      + rewrite H.
+        cbn.
+        elim (eq_dec x x) ; intros a.
+        * reflexivity.
+        * contradiction (eq_refl x).
+      + cbn.
+        elim (eq_dec x t) ; intros a.
+        * reflexivity.
+        * cbn.
+          rewrite (IH H).
+          reflexivity.
   Qed.
 
   Lemma remove'_In (X: Set)(eq_dec : forall x y : X, {x = y}+{x <> y})
     (x1 x2: X)(l: list X): In x1 l -> x1 <> x2 -> In x1 (remove' eq_dec x2 l).
   Proof.
     induction l as [|t l IH].
-    intros H ; inversion H.
-    intros [H1|H1] H2.
-    simpl.
-    elim (eq_dec x2 t) ; intros a.
-    contradiction (sym_eq (trans_eq a H1)).
-    left.
-    assumption.
-    simpl.
-    elim (eq_dec x2 t) ; intros a.
-    assumption.
-    right.
-    apply IH ; assumption.
+    - intros H ; inversion H.
+    - intros [H1|H1] H2.
+      + cbn.
+        elim (eq_dec x2 t) ; intros a.
+        * contradiction (sym_eq (trans_eq a H1)).
+        * left.
+          assumption.
+      + cbn.
+        elim (eq_dec x2 t) ; intros a.
+        * assumption.
+        * right.
+          apply IH ; assumption.
   Qed.
   
   Lemma NoDup_cons'(X: Set)(x: X)(l: list X) : NoDup (x::l) -> NoDup l.
@@ -212,108 +212,105 @@ Section Tools_lists.
     incl l1 l2 -> NoDup l1 -> length l1 = length l2 -> incl l2 l1.
   Proof.
     revert l2 ; induction l1 as [|t1 l1 IH] ; intros [|t2 l2] H1 H2 H3 x H4.
-    assumption.
-    inversion H3.
-    inversion H3.
-    destruct H4 as [H4 | H4].
-    rewrite <- H4 ; clear x H4.
-    destruct (H1 t1 (in_eq _ _)).
-    rewrite H ; apply in_eq.
-    inversion_clear H2 as [| t1' l1' H4 H5].
-    right.
-    apply (IH (remove' eq_dec t1 (t2 :: l2))).
-    intros x H6.
-    apply remove'_In.
-    apply (H1 x (in_cons _ _ _ H6)).
-    intro H7 ; rewrite H7 in H6 ; contradiction H6.
-    assumption.
-    apply eq_add_S.
-    rewrite remove'_In_length.
-    assumption.
-    apply (in_cons _ _ _ H).
-    
-    simpl.
-    elim (eq_dec t1 t2) ; intros a.
-    rewrite <- a ; assumption.
-    apply in_eq.
-    
-    elim (eq_dec t1 x) ; intros a.
-    left ; assumption.
-    right.
-    apply (IH (remove' eq_dec t1 (t2::l2))).
-    inversion_clear H2 as [| t1' l1' H5 H6].
-    intros x1 H7.
-
-    apply remove'_In.
-    apply H1, in_cons, H7.
-    intros H8 ; rewrite H8 in H7 ; contradiction H7.
-    apply (NoDup_cons' H2).
-    apply eq_add_S.
-    rewrite remove'_In_length.
-    assumption.
-    apply (H1 t1 (in_eq _ _)).
-    apply remove'_In.
-    apply (in_cons _ _ _ H4).
-    intro H ; contradiction (sym_eq H).
+    - assumption.
+    - inversion H3.
+    - inversion H3.
+    - destruct H4 as [H4 | H4].
+      + rewrite <- H4 ; clear x H4.
+        destruct (H1 t1 (in_eq _ _)).
+        * rewrite H ; apply in_eq.
+        * inversion_clear H2 as [| t1' l1' H4 H5].
+          right.
+          apply (IH (remove' eq_dec t1 (t2 :: l2))).
+          -- intros x H6.
+             apply remove'_In.
+             ++ apply (H1 x (in_cons _ _ _ H6)).
+             ++ intro H7 ; rewrite H7 in H6 ; contradiction H6.
+          -- assumption.
+          -- apply eq_add_S.
+             rewrite remove'_In_length.
+             ++ assumption.
+             ++ apply (in_cons _ _ _ H).
+          -- cbn.
+             elim (eq_dec t1 t2) ; intros a.
+             ++ rewrite <- a ; assumption.
+             ++ apply in_eq.
+      + elim (eq_dec t1 x) ; intros a.
+        * left ; assumption.
+        * right.
+          apply (IH (remove' eq_dec t1 (t2::l2))).
+          -- inversion_clear H2 as [| t1' l1' H5 H6].
+             intros x1 H7.
+             apply remove'_In.
+             ++ apply H1, in_cons, H7.
+             ++ intros H8 ; rewrite H8 in H7 ; contradiction H7.
+          -- apply (NoDup_cons' H2).
+          -- apply eq_add_S.
+             rewrite remove'_In_length.
+             ++ assumption.
+             ++ apply (H1 t1 (in_eq _ _)).
+          -- apply remove'_In.
+             ++ apply (in_cons _ _ _ H4).
+             ++ intro H ; contradiction (sym_eq H).
   Qed.
 
   Lemma incl_length2 (X: Set)(eq_dec : forall x y : X, {x = y}+{x <> y})(l1 l2 : list X): 
     incl l1 l2 -> NoDup l1 -> length l1 <= length l2.
   Proof.
-    revert l2 ; induction l1 as [|t1 l1 IH] ; intros l2 H1 H2.
-    apply le_0_n.
-    simpl.
-    rewrite <- (remove'_In_length eq_dec t1 l2).
-    apply le_n_S.
-    apply IH.
-    intros x H3.
-    apply remove'_In.
-    apply H1, (in_cons _ _ _ H3).
-    inversion_clear H2 as [| t1' l1' H4 H5].
-    intros H6.
-    rewrite H6 in H3 ; contradiction H3.
-    apply (NoDup_cons' H2).
-    apply (H1 _ (in_eq _ _)).
+    revert l2; induction l1 as [|t1 l1 IH]; intros l2 H1 H2.
+    - apply le_0_n.
+    - cbn.
+      rewrite <- (remove'_In_length eq_dec t1 l2).
+      + apply le_n_S.
+        apply IH.
+        * intros x H3.
+          apply remove'_In.
+          -- apply H1, (in_cons _ _ _ H3).
+          -- inversion_clear H2 as [| t1' l1' H4 H5].
+             intros H6.
+             rewrite H6 in H3 ; contradiction H3.
+        * apply (NoDup_cons' H2).
+      + apply (H1 _ (in_eq _ _)).
   Qed.
   
   Lemma cons_not_eq(X: Set): forall (x: X) l, x :: l <> l.
   Proof.
     intros x l ; revert x ; induction l ; intros x H.
-    inversion H.
-    inversion H.
-    apply (IHl a H2).
+    - inversion H.
+    - inversion H.
+      apply (IHl a H2).
   Qed.
 
   Lemma eq_list_nat_dec : forall (l l': list nat), {l = l'} + {not (l = l')}.
   Proof.
     induction l.
-    intros [| n l].
-    left.
-    reflexivity.
-    right.
-    intros H.
-    inversion H.
-    intros l'.
-    elim (IHl l') ; intros H.
-    rewrite H.
-    right.
-    apply cons_not_eq.
-    destruct l'.
-    right.
-    intros H1 ; inversion H1.
-    elim (eq_nat_dec a n) ; intros H1.
-    rewrite H1.
-    elim (IHl l') ; intros H2.
-    left.
-    f_equal; assumption.
-    right.
-    intros H3.
-    inversion H3.
-    contradiction H2.
-    right.
-    intros H3.
-    inversion H3.
-    contradiction H2.
+    - intros [| n l].
+      + left.
+        reflexivity.
+      + right.
+        intros H.
+        inversion H.
+    - intros l'.
+      elim (IHl l') ; intros H.
+      + rewrite H.
+        right.
+        apply cons_not_eq.
+      + destruct l'.
+        * right.
+          intros H1 ; inversion H1.
+        * elim (eq_nat_dec a n) ; intros H1.
+          -- rewrite H1.
+             elim (IHl l') ; intros H2.
+             ++ left.
+                f_equal; assumption.
+             ++ right.
+                intros H3.
+                inversion H3.
+                contradiction H2.
+          -- right.
+             intros H3.
+             inversion H3.
+             contradiction H2.
   Qed.
 End Tools_lists.
 
@@ -323,8 +320,8 @@ Section Tools_arith.
   Proof.
     intros m n h.
     apply lt_minus.
-    apply (lt_le_S m n h).
-    apply lt_O_Sn.
+    - apply (lt_le_S m n h).
+    - apply lt_O_Sn.
   Qed.
 
   Lemma Sn_Sm_eq_n_m: forall (n m: nat), (S n) - (S m) = n - m.
@@ -343,14 +340,14 @@ Section Tools_arith.
   Proof.
     intros n m h H.
     elim (lt_eq_lt_dec m 0); intros a.
-    inversion_clear a as [H0|e].
-    inversion H0.
-    assumption.
-    apply False_rec.
-    assert (n-m < n).
-    apply (lt_minus _ _ h a).
-    rewrite H in H0.
-    apply (lt_irrefl _ H0).
+    - inversion_clear a as [H0|e].
+      + inversion H0.
+      + assumption.
+    - apply False_rec.
+      assert (n-m < n).
+      { apply (lt_minus _ _ h a). }
+      rewrite H in H0.
+      apply (lt_irrefl _ H0).
   Qed.
 
   Lemma lt_plus_S : forall n m, n < n + (S m).
@@ -363,22 +360,22 @@ Section Tools_arith.
   Lemma minus_n_m_0 (n m: nat) : m <= n -> n - m = 0 -> n = m.
   Proof.
     revert m ; induction n as [|n IH] ; intros m h1 h2.
-    symmetry.
-    apply (minus_reg_l h1 h2).
-    destruct m as [|m].
-    inversion h2.
-    apply eq_S.
-    apply IH.
-    apply le_S_n, h1.
-    rewrite <- Sn_Sm_eq_n_m; assumption.
+    - symmetry.
+      apply (minus_reg_l h1 h2).
+    - destruct m as [|m].
+      + inversion h2.
+      + apply eq_S.
+        apply IH.
+        * apply le_S_n, h1.
+        * rewrite <- Sn_Sm_eq_n_m; assumption.
   Qed.
 
   Lemma lt_minus_S: forall m n: nat, m < n -> (n - (S m)) < n.
   Proof.
     intros m n h.
     apply lt_minus.
-    apply (lt_le_S m n h).
-    apply lt_O_Sn.
+    - apply (lt_le_S m n h).
+    - apply lt_O_Sn.
   Qed.
 
   Lemma lt_n_m_0: forall m n: nat, m < n -> 0 < n.
@@ -407,33 +404,33 @@ Section Tools_option.
   Definition RelOp (T: Set)(RelT: relation T): relation (option T).
   Proof.
     intros [t1|] [t2|].
-    exact (RelT t1 t2).
-    exact False.
-    exact False.
-    exact True.
+    - exact (RelT t1 t2).
+    - exact False.
+    - exact False.
+    - exact True.
   Defined.
 
   Lemma RelOp_refl (T: Set)(RelT: relation T)(Req: Reflexive RelT)(ot: option T): 
     RelOp RelT ot ot.
   Proof.
-    destruct ot as [t|] ; simpl ; reflexivity.
+    destruct ot as [t|] ; cbn ; reflexivity.
   Qed.
   
   Lemma RelOp_sym (T: Set)(RelT: relation T)(Req: Symmetric RelT)(ot1 ot2: option T): 
     RelOp RelT ot1 ot2 -> RelOp RelT ot2 ot1.
   Proof.
-    intros H ; destruct ot1 as [t1|] ; destruct ot2 as [t2|] ; simpl ; try inversion H.
-    simpl in H ; symmetry ; assumption.
-    reflexivity.
+    intros H ; destruct ot1 as [t1|] ; destruct ot2 as [t2|] ; cbn ; try inversion H.
+    - cbn in H ; symmetry ; assumption.
+    - reflexivity.
   Qed.
   
   Lemma RelOp_trans (T: Set)(RelT: relation T)(Req: Transitive RelT)(ot1 ot2 ot3: option T): 
     RelOp RelT ot1 ot2 -> RelOp RelT ot2 ot3 -> RelOp RelT ot1 ot3.
   Proof.
     intros H1 H2 ; destruct ot1 as [t1|] ; destruct ot2 as [t2|] ; destruct ot3 as [t3|] ; 
-    simpl ; try inversion H1 ; try inversion H2.
-    simpl in H1, H2 ; transitivity t2 ; assumption.
-    reflexivity.
+    cbn ; try inversion H1 ; try inversion H2.
+    - cbn in H1, H2 ; transitivity t2 ; assumption.
+    - reflexivity.
   Qed.
   
   Add Parametric Relation (T: Set)(RelT: relation T)(Req: Equivalence RelT): 
@@ -461,12 +458,12 @@ Section Bijective.
    Proof.
      intros [h1 h2] [h3 h4].
      split.
-     intros t.
-     rewrite h3.
-     apply h1.
-     intros u.
-     rewrite h2.
-     apply h4.
+     - intros t.
+       rewrite h3.
+       apply h1.
+     - intros u.
+       rewrite h2.
+       apply h4.
    Qed.
 
   Lemma bij_inj (A B: Set)(f : A -> B)(g : B -> A): 

--- a/allGraphs.v
+++ b/allGraphs.v
@@ -19,7 +19,7 @@ Require Import GPerm.
 
 Set Implicit Arguments.
 
-Section AllGraphs_def_tools. 
+Section AllGraphs_def_tools.
 
   Variable T: Set.
   (* Definition of coinductive graphs *)
@@ -119,57 +119,54 @@ Lemma two_roots_ForestGr_two_roots_AllGraph :
   Geq (RelOp eq) two_roots_AllGraph (FG2AG two_roots_ForestGr).
 Proof.
   apply Geq_intro.
-  
-  simpl.
-  trivial.
-  
+  { cbn.
+    trivial. }
   assert (h1 := refl_equal _: lgti (sons two_roots_AllGraph) = lgti (sons (FG2AG two_roots_ForestGr))).
   apply (is_ilist_rel _ _ _ h1).
   intro i.
-  simpl in *|-*.
+  cbn in *|-*.
   rewrite <- decode_Fin_match'.
   elim (zerop (decode_Fin i)) ; intros a.
-  rewrite (decode_Fin_0_first _ a).
-  apply Geq_intro.
-  reflexivity.
-  simpl.
-  assert (h2 := refl_equal _ : 
-  lgti (icons (mk_Graph (Some 0) (inil (AllGraph nat))) (inil (AllGraph nat))) = 
-  lgti (imap (@G2AG _)(icons (mk_Graph 0 (inil (Graph nat))) (inil (Graph nat))))).
-  apply (is_ilist_rel _ _ _ h2).
-  simpl in *|-*.
-  intro i'.
-  rewrite <- (decode_Fin_unique _ _ (decode_Fin_match' i' h2)).
-  rewrite (Fin_first_1 i').
-  apply Geq_intro.
-  reflexivity.
-  simpl.
-  assert (h3 := refl_equal _ : lgti (inil (AllGraph nat)) = lgti (imap (@G2AG _) (inil (Graph nat)))).
-  apply (is_ilist_rel _ _ _ h3).
-  intro i'' ; inversion i''.
-  
-  assert (h2 : i = succ (first 0)).
-  apply decode_Fin_unique.
-  apply symmetry, (le_antisym _ _ (lt_le_S _ _ a) (lt_n_Sm_le _ _ (decode_Fin_inf_n i))).
-  rewrite h2 ; clear h2.
-  simpl.
-  apply Geq_intro.
-  reflexivity.
-  simpl.
-  assert (h2 := refl_equal _ : 
-  lgti (icons (mk_Graph (Some 0) (inil (AllGraph nat))) (inil (AllGraph nat))) = 
-  lgti (imap (@G2AG _)(icons (mk_Graph 0 (inil (Graph nat))) (inil (Graph nat))))).
-  apply (is_ilist_rel _ _ _ h2).
-  simpl in *|-*.
-  intro i'.
-  rewrite <- (decode_Fin_unique _ _ (decode_Fin_match' i' h2)).
-  rewrite (Fin_first_1 i').
-  apply Geq_intro.
-  reflexivity.
-  simpl.
-  assert (h3 := refl_equal _ : lgti (inil (AllGraph nat)) = lgti (imap (@G2AG _) (inil (Graph nat)))).
-  apply (is_ilist_rel _ _ _ h3).
-  intro i'' ; inversion i''.
+  - rewrite (decode_Fin_0_first _ a).
+    apply Geq_intro.
+    + reflexivity.
+    + cbn.
+      assert (h2 := refl_equal _ : 
+      lgti (icons (mk_Graph (Some 0) (inil (AllGraph nat))) (inil (AllGraph nat))) = 
+      lgti (imap (@G2AG _)(icons (mk_Graph 0 (inil (Graph nat))) (inil (Graph nat))))).
+      apply (is_ilist_rel _ _ _ h2).
+      cbn in *|-*.
+      intro i'.
+      rewrite <- (decode_Fin_unique _ _ (decode_Fin_match' i' h2)).
+      rewrite (Fin_first_1 i').
+      apply Geq_intro.
+      * reflexivity.
+      * cbn.
+        assert (h3 := refl_equal _ : lgti (inil (AllGraph nat)) = lgti (imap (@G2AG _) (inil (Graph nat)))).
+        apply (is_ilist_rel _ _ _ h3).
+        intro i'' ; inversion i''.
+  - assert (h2 : i = succ (first 0)).
+    { apply decode_Fin_unique.
+      apply symmetry, (le_antisym _ _ (lt_le_S _ _ a) (lt_n_Sm_le _ _ (decode_Fin_inf_n i))). }
+    rewrite h2 ; clear h2.
+    cbn.
+    apply Geq_intro.
+    + reflexivity.
+    + cbn.
+      assert (h2 := refl_equal _ : 
+      lgti (icons (mk_Graph (Some 0) (inil (AllGraph nat))) (inil (AllGraph nat))) = 
+      lgti (imap (@G2AG _)(icons (mk_Graph 0 (inil (Graph nat))) (inil (Graph nat))))).
+      apply (is_ilist_rel _ _ _ h2).
+      cbn in *|-*.
+      intro i'.
+      rewrite <- (decode_Fin_unique _ _ (decode_Fin_match' i' h2)).
+      rewrite (Fin_first_1 i').
+      apply Geq_intro.
+      * reflexivity.
+      * cbn.
+        assert (h3 := refl_equal _ : lgti (inil (AllGraph nat)) = lgti (imap (@G2AG _) (inil (Graph nat)))).
+        apply (is_ilist_rel _ _ _ h3).
+        intro i'' ; inversion i''.
 Qed.
 
 

--- a/allGraphs.v
+++ b/allGraphs.v
@@ -61,7 +61,7 @@ Section AllGraphs_def_tools.
   
   CoFixpoint G2AG (g: Graph T) : AllGraph := mk_Graph (Some (label g)) (imap G2AG (sons g)).
   
-  CoFixpoint FG2AG (lg : ForestGr) : AllGraph := mk_Graph None (list2ilist (map G2AG lg)).
+  Definition FG2AG (lg : ForestGr) : AllGraph := mk_Graph None (list2ilist (map G2AG lg)).
   
   Definition FGeq (R: relation T) : relation ForestGr := permut1 (GPPerm R).
   


### PR DESCRIPTION
mostly structuring elements (bullets and braces) systematically used, most uses of simpl replaced by cbn